### PR TITLE
docs: Update build-time dependencies for Debian/Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Install extra deps on Linux
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y libmpfr-dev libboost-dev
+      run: sudo apt-get update && sudo apt-get install -y libboost-dev gfortran swig autoconf libtool
 
     #- name: Install dependency
     #  run: python -m pip install awkward

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Install extra deps on Linux
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y libmpfr-dev libboost-dev
+      run: sudo apt-get update && sudo apt-get install -y libboost-dev gfortran swig autoconf libtool
 
     - name: test sdist
       run: python -m pip install dist/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 *.exe
 *.out
 *.app
+
+# Build dependencies
+CGAL*

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 Official FastJet bindings to Python and Awkward Array.
 
-Main features of Fastjet :
+Main features of Fastjet:
   * Contains Vectorized as well as Non-Vectorized interface for Fastjet.
   * Compiled against the complete Fastjet library in C++.
   * Has Awkward Array and Vector as dependency.
@@ -41,9 +41,9 @@ Main features of Fastjet :
   * Input data can be in any coordinate system.
 
 # Installation
-The package can be installed from pypi using the following command :
+The package can be installed from PyPI using the following command:
 ``` bash
-pip install fastjet
+python -m pip install fastjet
 ```
 # Overview
 
@@ -103,5 +103,5 @@ sudo apt-get update && sudo apt-get install -y libmpfr-dev libboost-dev
 ```
 Then you can build it using the following command:
 ``` bash
-pip install .[test]
+python -m pip install .[test]
 ```

--- a/README.md
+++ b/README.md
@@ -97,10 +97,24 @@ inclusive_jets = cluster.inclusive_jets()
 ```
 # Installation For Developers
 Clone this repository recursively to get the dependencies.
-Run the following command before building it :
-``` bash
-sudo apt-get update && sudo apt-get install -y libmpfr-dev libboost-dev
+
 ```
+git clone --recuse-submodules git@github.com:scikit-hep/fastjet.git
+```
+
+## Build dependencies
+
+There are still external build-time dependencies for the C++ components of `fastjet` that need to be installed on the build machine.
+To install the build-time dependencies run the following installation commands for your respective operating system:
+
+### Debian/Ubuntu
+
+``` bash
+sudo apt-get update && sudo apt-get install -y libboost-dev gfortran swig autoconf libtool
+```
+
+## Build and install
+
 Then you can build it using the following command:
 ``` bash
 python -m pip install .[test]


### PR DESCRIPTION
Resolves #55 

**Suggested squash and merge commit message**:
```
* Update build-time dependencies for Debian based operating systems
   - Add: gfortran swig autoconf libtool
   - Note that these are for Debian/Ubuntu
* Update build-time dependencies in CI to match those in docs
* Advocate for using `python -m pip` in all uses of `pip`
* Add CGAL to .gitignore
```