### PR TITLE
remove --enable-cgal for rc6, re-enable in rc7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             args = [
                 f"--prefix={OUTPUT}",
                 "--enable-allplugins",
+                "--disable-shared",
                 "--enable-cgal-header-only",
                 f"--with-cgaldir={cgal_dir}",
                 "--enable-swig",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             args = [
                 f"--prefix={OUTPUT}",
                 "--enable-allplugins",
-                "--enable-cgal",
                 "--enable-cgal-header-only",
                 f"--with-cgaldir={cgal_dir}",
                 "--enable-swig",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             args = [
                 f"--prefix={OUTPUT}",
                 "--enable-allplugins",
-                "--disable-shared",
                 "--enable-cgal-header-only",
                 f"--with-cgaldir={cgal_dir}",
                 "--enable-swig",


### PR DESCRIPTION
https://gitlab.com/fastjet/fastjet/-/blob/fastjet-3.3.4/INSTALL#L55-60

Critically it is necessary to remove this line for builds to work on centos7.
It does not affect building on debian-likes.