### PR TITLE
Add $ORIGIN/_fastjet_core/lib to RPATH for PyPI wheels.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
       matrix:
         python-version: [3.6, 3.9]
         runs-on: [ubuntu-latest, macos-latest]
-        include:
-        - python-version: pypy-3.6
-          runs-on: ubuntu-latest
+
+        # include:
+        # - python-version: pypy-3.6
+        #   runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         CIBW_ARCHS: auto64
         CIBW_BUILD: cp39-*
         CIBW_BUILD_VERBOSITY: 2
+        CIBW_REPAIR_WHEEL_COMMAND: ""
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       run: python -m pytest -vv -rs -Wd
 
   test_wheels:
-    name: Wheel on linux
+    name: Wheel on Linux
     runs-on: ubuntu-latest
 
     steps:
@@ -68,9 +68,11 @@ jobs:
       with:
         submodules: recursive
 
-    - uses: pypa/cibuildwheel@v2.0.1
+    - uses: pypa/cibuildwheel@v2.1.1
       env:
-        CIBW_BUILD: cp39-manylinux_x86_64
+        CIBW_ARCHS: auto64
+        CIBW_BUILD: cp39-*
+        CIBW_BUILD_VERBOSITY: 2
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.9]
-        runs-on: [ubuntu-latest, macos-latest]
+        runs-on: [ubuntu-latest]   # , macos-latest
 
         # include:
         # - python-version: pypy-3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install automake swig gmp mpfr boost
 
-    - name: "Try 'xcode-select --install'"
-      if: runner.os == 'macOS'
-      run: xcode-select --install
-
     - name: Install extra deps on Linux
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install automake swig gmp mpfr boost
 
+    - name: "Try 'xcode-select --install'"
+      if: runner.os == 'macOS'
+      run: xcode-select --install
+
     - name: Install extra deps on Linux
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
 
     - name: Install compiler tools on macOS
       if: runner.os == 'macOS'
-      run: brew install automake swig gmp mpfr boost gfortran
+      run: brew install automake swig gmp mpfr boost
 
     - name: Install extra deps on Linux
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y libboost-dev gfortran swig autoconf libtool
+      run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool
 
     #- name: Install dependency
     #  run: python -m pip install awkward

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
         CIBW_ARCHS: auto64
         CIBW_BUILD: cp39-*
         CIBW_BUILD_VERBOSITY: 2
-        CIBW_REPAIR_WHEEL_COMMAND: ""
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.9]
-        runs-on: [ubuntu-latest]  # macos-latest isn't setting up cgal yet
-
-        # include:
-        # - python-version: pypy-3.6
-        #   runs-on: ubuntu-latest
+        runs-on: [ubuntu-latest, macos-latest]
+        include:
+        - python-version: pypy-3.6
+          runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -52,12 +51,6 @@ jobs:
     - name: Install extra deps on Linux
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool
-
-    #- name: Install dependency
-    #  run: python -m pip install awkward
-
-    #- name: Install dependency
-    #  run: python -m pip install vector
 
     - name: Install package
       run: python -m pip install .[test] -v

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,27 +22,27 @@ jobs:
       with:
         path: dist/*.tar.gz
 
-  #build_wheels:
-    #name: Wheel on ${{ matrix.os }}
-    #runs-on: ${{ matrix.os }}
-    #strategy:
-      #fail-fast: false
-      #matrix:
-        #os: [ubuntu-latest] #, macos-latest]
+  build_wheels:
+    name: Wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest] #, macos-latest]
 
-    #steps:
-    #- uses: actions/checkout@v2
-      #with:
-        #submodules: recursive
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
 
-    #- uses: pypa/cibuildwheel@v2.0.0a4
-      #env:
-        #CIBW_ARCHS: auto64
+    - uses: pypa/cibuildwheel@v2.0.0a4
+      env:
+        CIBW_ARCHS: auto64
 
-    #- name: Upload wheels
-      #uses: actions/upload-artifact@v2
-      #with:
-        #path: wheelhouse/*.whl
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl
 
   test_sdist:
     needs: [make_sdist]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,6 +50,22 @@ jobs:
       with:
         path: wheelhouse/*.whl
 
+  test_wheels:
+    name: Wheel on linux
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+
+    - uses: pypa/cibuildwheel@v2.0.0a4
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl
+
   test_sdist:
     needs: [make_sdist]
     runs-on: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,7 +40,7 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install automake
 
-    - uses: pypa/cibuildwheel@v2.0.0a4
+    - uses: pypa/cibuildwheel@v2.1.1
       env:
         CIBW_ARCHS: auto64
         CIBW_BUILD: ${{ matrix.python-build-version }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,6 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-build-version: ["cp36-*", "cp37-*", "cp38-*", "cp39-*"]
         os: [ubuntu-latest] #, macos-latest]
 
     steps:
@@ -38,6 +39,7 @@ jobs:
     - uses: pypa/cibuildwheel@v2.0.0a4
       env:
         CIBW_ARCHS: auto64
+        CIBW_BUILD: ${{ matrix.python-build-version }}
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2
@@ -55,13 +57,13 @@ jobs:
 
     - name: Install extra deps on Linux
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y libboost-dev gfortran swig autoconf libtool
+      run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool
 
     - name: test sdist
       run: python -m pip install dist/*.tar.gz
 
   upload_all:
-    needs: [make_sdist] #[build_wheels,
+    needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,22 +50,6 @@ jobs:
       with:
         path: wheelhouse/*.whl
 
-  test_wheels:
-    name: Wheel on linux
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: recursive
-
-    - uses: pypa/cibuildwheel@v2.1.1
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v2
-      with:
-        path: wheelhouse/*.whl
-
   test_sdist:
     needs: [make_sdist]
     runs-on: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,6 +44,7 @@ jobs:
       env:
         CIBW_ARCHS: auto64
         CIBW_BUILD: ${{ matrix.python-build-version }}
+        CIBW_BUILD_VERBOSITY: 2
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
       with:
         submodules: recursive
 
-    - uses: pypa/cibuildwheel@v2.0.0a4
+    - uses: pypa/cibuildwheel@v2.1.1
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,13 +23,13 @@ jobs:
         path: dist/*.tar.gz
 
   build_wheels:
-    name: Wheel on ${{ matrix.os }}
+    name: Make ${{ matrix.os }}, ${{ matrix.python-build-version }} Wheels
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-build-version: ["cp36-*", "cp37-*", "cp38-*", "cp39-*"]
-        os: [ubuntu-latest] #, macos-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         python-build-version: ["cp36-*", "cp37-*", "cp38-*", "cp39-*"]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]   # , macos-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,10 +40,6 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install automake
 
-    - name: "Try 'xcode-select --install'"
-      if: runner.os == 'macOS'
-      run: xcode-select --install
-
     - uses: pypa/cibuildwheel@v2.0.0a4
       env:
         CIBW_ARCHS: auto64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,10 +1,10 @@
 name: wheels
 
-on:
-  workflow_dispatch:
-  release:
-    types:
-      - published
+# on:
+#   workflow_dispatch:
+#   release:
+#     types:
+#       - published
 
 jobs:
   make_sdist:
@@ -23,7 +23,7 @@ jobs:
         path: dist/*.tar.gz
 
   build_wheels:
-    name: Make ${{ matrix.os }}, ${{ matrix.python-build-version }} Wheels
+    name: Make ${{ matrix.python-build-version }} ${{ matrix.os }} Wheels
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -35,6 +35,14 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+
+    - name: Install compiler tools on macOS
+      if: runner.os == 'macOS'
+      run: brew install automake swig gmp mpfr boost
+
+    - name: Install extra deps on Linux
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool
 
     - uses: pypa/cibuildwheel@v2.0.0a4
       env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,10 +1,10 @@
 name: wheels
 
-# on:
-#   workflow_dispatch:
-#   release:
-#     types:
-#       - published
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
 
 jobs:
   make_sdist:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,11 +38,11 @@ jobs:
 
     - name: Install compiler tools on macOS
       if: runner.os == 'macOS'
-      run: brew install automake swig gmp mpfr boost
+      run: brew install automake
 
-    - name: Install extra deps on Linux
-      if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool
+    - name: "Try 'xcode-select --install'"
+      if: runner.os == 'macOS'
+      run: xcode-select --install
 
     - uses: pypa/cibuildwheel@v2.0.0a4
       env:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To install the build-time dependencies run the following installation commands f
 ### Debian/Ubuntu
 
 ``` bash
-sudo apt-get update && sudo apt-get install -y libboost-dev gfortran swig autoconf libtool
+sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool
 ```
 
 ## Build and install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ build-backend = "setuptools.build_meta"
 skip = "pp*"
 test-extras = "test"
 test-command = "pytest {project}/tests"
-manylinux-x86_64-image = "manylinux_2_24"
-manylinux-i686-image = "manylinux_2_24"
 
 [tool.cibuildwheel.linux]
 before-all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 skip = "pp*"
 test-extras = "test"
-test-command = ""
+test-command = "pytest {project}/tests"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,11 @@ build-backend = "setuptools.build_meta"
 skip = "pp*"
 test-extras = "test"
 test-command = "pytest {project}/tests"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
 
 [tool.cibuildwheel.linux]
 before-all = [
-    "apt-get update -y",
-    "apt-get install -y libmpfr-dev libboost-dev",
+    "yum update -y",
+    "yum install -y mpfr-devel boost-devel",
 ]
-repair-wheel-command = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 skip = "pp*"
 test-extras = "test"
-test-command = "pytest {project}/tests"
+test-command = ""
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 

--- a/setup.py
+++ b/setup.py
@@ -100,9 +100,8 @@ class FastJetInstall(setuptools.command.install.install):
 ' print-pythondir""",
                 shell=True,
                 cwd=FASTJET,
-            )
-            .decode()
-            .strip()
+                universal_newlines=True,
+            ).strip()
         )
 
         pyexecdir = pathlib.Path(

--- a/setup.py
+++ b/setup.py
@@ -112,8 +112,8 @@ class FastJetInstall(setuptools.command.install.install):
 ' print-pyexecdir""",
                 shell=True,
                 cwd=FASTJET,
+                universal_newlines=True,
             )
-            .decode()
             .strip()
         )
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
 
             subprocess.run(["./autogen.sh"] + args, cwd=FASTJET, env=env, check=True)
 
-            env = {"ORIGIN": "$ORIGIN"}  # if evaluated, it will still be '$ORIGIN'
+            env = os.environ.copy()
+            env["ORIGIN"] = "$ORIGIN"  # if evaluated, it will still be '$ORIGIN'
             subprocess.run(["make", "-j"], cwd=FASTJET, env=env, check=True)
             subprocess.run(["make", "install"], cwd=FASTJET, env=env, check=True)
 

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,11 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 "LDFLAGS=-Wl,-rpath=$$ORIGIN/_fastjet_core/lib:$$ORIGIN",
             ]
 
-            subprocess.run(["./autogen.sh"] + args, cwd=FASTJET, env=env, check=True)
+            try:
+                subprocess.run(["./autogen.sh"] + args, cwd=FASTJET, env=env, check=True)
+            except Exception:
+                subprocess.run(["cat", "config.log"], cwd=FASTJET, check=True)
+                raise
 
             env = os.environ.copy()
             env["ORIGIN"] = "$ORIGIN"  # if evaluated, it will still be '$ORIGIN'

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 f"--with-cgaldir={cgal_dir}",
                 "--enable-swig",
                 "--enable-pyext",
-                "LDFLAGS=-Wl,-rpath=$$ORIGIN/_fastjet_core/lib",
+                "LDFLAGS=-Wl,-rpath=$$ORIGIN/_fastjet_core/lib:$$ORIGIN",
             ]
 
             subprocess.run(["./autogen.sh"] + args, cwd=FASTJET, env=env, check=True)

--- a/setup.py
+++ b/setup.py
@@ -82,13 +82,25 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             subprocess.run(["make", "-j"], cwd=FASTJET, env=env, check=True)
             subprocess.run(["make", "install"], cwd=FASTJET, env=env, check=True)
 
+            print("FastJetBuild ========================================")  # noqa: T001
+            tree(str(OUTPUT))
+
             for pythondir in (OUTPUT / "lib").glob("python*"):
                 sitepackages = pythondir / "site-packages"
                 shutil.copyfile(sitepackages / "fastjet.py", PYTHON / "_swig.py")
                 for sharedobj in sitepackages.glob("*.so*"):
                     shutil.copyfile(sharedobj, PYTHON / sharedobj.parts[-1])
 
+            print("=====================================================")  # noqa: T001
+
         setuptools.command.build_ext.build_ext.build_extensions(self)
+
+
+def tree(x):
+    print(("{} (dir)" if os.path.isdir(x) else "{}").format(x))  # noqa: T001
+    if os.path.isdir(x):
+        for y in os.listdir(x):
+            tree(os.path.join(x, y))
 
 
 class FastJetInstall(setuptools.command.install.install):
@@ -99,6 +111,9 @@ class FastJetInstall(setuptools.command.install.install):
 
         shutil.copytree(OUTPUT, fastjetdir / "_fastjet_core")
 
+        print("FastJetInstall ======================================")  # noqa: T001
+        tree(str(fastjetdir / "_fastjet_core"))
+
         for pythondir in (fastjetdir / "_fastjet_core/lib").glob("python*"):
             sitepackages = pythondir / "site-packages"
             (sitepackages / "fastjet.py").rename(fastjetdir / "_swig.py")
@@ -106,6 +121,8 @@ class FastJetInstall(setuptools.command.install.install):
                 sharedobj.rename(fastjetdir / sharedobj.parts[-1])
 
             shutil.rmtree(pythondir)
+
+        print("=====================================================")  # noqa: T001
 
         setuptools.command.install.install.run(self)
 

--- a/setup.py
+++ b/setup.py
@@ -113,8 +113,7 @@ class FastJetInstall(setuptools.command.install.install):
                 shell=True,
                 cwd=FASTJET,
                 universal_newlines=True,
-            )
-            .strip()
+            ).strip()
         )
 
         shutil.copyfile(pythondir / "fastjet.py", fastjetdir / "_swig.py")

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ class FastJetInstall(setuptools.command.install.install):
         pythondir = pathlib.Path(
             subprocess.check_output(
                 """make -f pyinterface/Makefile --eval='print-pythondir:
-	@echo $(pythondir)
+\t@echo $(pythondir)
 ' print-pythondir""",
                 shell=True,
                 cwd=FASTJET,
@@ -108,7 +108,7 @@ class FastJetInstall(setuptools.command.install.install):
         pyexecdir = pathlib.Path(
             subprocess.check_output(
                 """make -f pyinterface/Makefile --eval='print-pyexecdir:
-	@echo $(pyexecdir)
+\t@echo $(pyexecdir)
 ' print-pyexecdir""",
                 shell=True,
                 cwd=FASTJET,

--- a/setup.py
+++ b/setup.py
@@ -56,14 +56,12 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             env = os.environ.copy()
             env["PYTHON"] = sys.executable
             env["PYTHON_INCLUDE"] = f'-I{sysconfig.get_path("include")}'
-            env["CXXFLAGS"] = "-O3 -Bstatic -lgmp -lgfortran -Bdynamic"
-            if sys.platform.startswith("darwin"):
-                env["FC"] = "gfortran"
+            env["CXXFLAGS"] = "-O3 -Bstatic -lgmp -Bdynamic"
             env["ORIGIN"] = "$ORIGIN"  # if evaluated, it will still be '$ORIGIN'
 
             args = [
                 f"--prefix={OUTPUT}",
-                "--enable-allplugins",
+                "--enable-allcxxplugins",
                 "--enable-cgal-header-only",
                 f"--with-cgaldir={cgal_dir}",
                 "--enable-swig",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,9 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             ]
 
             try:
-                subprocess.run(["./autogen.sh"] + args, cwd=FASTJET, env=env, check=True)
+                subprocess.run(
+                    ["./autogen.sh"] + args, cwd=FASTJET, env=env, check=True
+                )
             except Exception:
                 subprocess.run(["cat", "config.log"], cwd=FASTJET, check=True)
                 raise

--- a/src/fastjet/__init__.py
+++ b/src/fastjet/__init__.py
@@ -1,18 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/fastjet/blob/main/LICENSE
-import ctypes
-import pathlib
 
 import awkward as ak
-
-_fastjet_core = pathlib.Path(__file__).parent.resolve() / "_fastjet_core" / "lib"
-_libfastjet = ctypes.cdll.LoadLibrary(_fastjet_core / "libfastjet.so")
-_libfastjettools = ctypes.cdll.LoadLibrary(_fastjet_core / "libfastjettools.so")
-_libsiscone = ctypes.cdll.LoadLibrary(_fastjet_core / "libsiscone.so")
-_libsiscone_spherical = ctypes.cdll.LoadLibrary(
-    _fastjet_core / "libsiscone_spherical.so"
-)
-_libfastjetplugins = ctypes.cdll.LoadLibrary(_fastjet_core / "libfastjetplugins.so")
-
 
 import fastjet._ext  # noqa: F401, E402
 import fastjet._pyjet  # noqa: F401, E402

--- a/src/fastjet/version.py
+++ b/src/fastjet/version.py
@@ -2,7 +2,7 @@
 
 import re
 
-__version__ = "3.3.4.0rc6"
+__version__ = "3.3.4.0rc7"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 

--- a/src/fastjet/version.py
+++ b/src/fastjet/version.py
@@ -2,7 +2,7 @@
 
 import re
 
-__version__ = "3.3.4.0rc7"
+__version__ = "3.3.4.0rc8"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Summary of this PR:

   * All ldd "Not Found" errors were resolved by linking with `-rpath=$ORIGIN/_fastjet_core/lib`, with sufficient quoting on the "`$ORIGIN`". Different parts of the configure/make procedure evaluate it at different levels, so just protecting the `$` is not enough: I had to define an environment variable so that `$ORIGIN` would resolve to "`$ORIGIN`".
   * Dropped PxCone because libgfortran is not found. According to @lgray, "PxCone is from 2006 and was most recently cited in a Herwig benchmarking paper for completeness in 2016." It's probably safe to ignore PxCone.
   * Intermediate commits were attempts to get it to work on MacOS. [Last attempt in ci.yml](https://github.com/scikit-hep/fastjet/actions/runs/1137341103), and [last attempt in wheels.yml](https://github.com/scikit-hep/fastjet/actions/runs/1137342116), which are both from bb4afab59cb72f9ea04b520990641402af03a27d.
   * After all that, I tried making [release v3.3.4.0rc7](https://github.com/scikit-hep/fastjet/releases/tag/v3.3.4.0rc7), but this failed because we weren't actually running auditwheel.
   * Restored the cibuildwheel infrastructure to its original state, with `pypa/cibuildwheel@v2.0.1`, following @henryiii's suggestion.
   * FastJet's `./configure`, when it runs inside cibuildwheel, puts the SWIG-generated Python files in a different location. The only way I see to get it is to extract it directly from the `pyinterface/Makefile`. (A banner asking users to set `PYTHONPATH` tells us which variables hold the directory locations.)
   * At the time of writing (just after 1065e43120f5cdf7b3e6e2e292229b355d9fb81a), wheels have been [uploaded to PyPI](https://pypi.org/project/fastjet/3.3.4.0rc8/#files) and successfully tested with `pip install --pre fastjet`!
   * However, the shared libraries have identical files named `libxyz.so`, `libxyz.so.0`, and `libxyz.so.0.0.0`. Presumably, they were originally symbolic links, but now they're duplicates. Removing the two excess copies would reduce the total wheel size by 1/3. (Uncompressed, the extra two copies add up to 52 MB out of 156 MB.) Perhaps the `.0` and `.0.0.0` versions can be dropped in MANIFEST.in?