### PR TITLE
Bump FastJet version to 3.4.0 from 3.3.4 using a patch

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ graft tests
 graft fastjet-core
 graft pybind11
 global-exclude .git .gitmodules
-include LICENSE README.md pyproject.toml setup.py setup.cfg
+include LICENSE README.md pyproject.toml setup.py setup.cfg patch.sed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ graft tests
 graft fastjet-core
 graft pybind11
 global-exclude .git .gitmodules
-include LICENSE README.md pyproject.toml setup.py setup.cfg patch.sed
+include LICENSE README.md pyproject.toml setup.py setup.cfg patch.txt

--- a/patch.sed
+++ b/patch.sed
@@ -1,0 +1,1 @@
+s/from _fastjet import FastJetError/if __package__ or "." in __name__:\n    from ._fastjet import FastJetError\n  else:\n    from _fastjet import FastJetError/g

--- a/patch.sed
+++ b/patch.sed
@@ -1,1 +1,0 @@
-s/from _fastjet import FastJetError/if __package__ or "." in __name__:\n    from ._fastjet import FastJetError\n  else:\n    from _fastjet import FastJetError/g

--- a/patch.txt
+++ b/patch.txt
@@ -1,0 +1,14 @@
+--- fastjet-core/pyinterface/fastjet.i	2022-10-25 23:22:36.000000000 +0200
++++ fastjet-core/pyinterface/fastjet_p.i	2022-10-26 16:25:20.000000000 +0200
+@@ -138,7 +138,10 @@
+ 
+ // include FastJetError in python module
+ %pythoncode {
+-  from _fastjet import FastJetError
++  if __package__ or "." in __name__:
++    from ._fastjet import FastJetError
++  else:
++    from _fastjet import FastJetError
+ }
+ 
+ FASTJET_ERRORS_AS_PYTHON_EXCEPTIONS(fastjet)

--- a/patch.txt
+++ b/patch.txt
@@ -1,7 +1,7 @@
 --- fastjet-core/pyinterface/fastjet.i	2022-10-25 23:22:36.000000000 +0200
 +++ fastjet-core/pyinterface/fastjet_p.i	2022-10-26 16:25:20.000000000 +0200
 @@ -138,7 +138,10 @@
- 
+
  // include FastJetError in python module
  %pythoncode {
 -  from _fastjet import FastJetError
@@ -10,5 +10,5 @@
 +  else:
 +    from _fastjet import FastJetError
  }
- 
+
  FASTJET_ERRORS_AS_PYTHON_EXCEPTIONS(fastjet)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,12 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 cgal_dir = DIR / zip_obj.namelist()[0]
                 zip_obj.extractall(DIR)
 
+            # Patch for FastJet core version 3.4.0
+            # To be removed when it is applied upstream
+            oldCode = "from _fastjet import FastJetError"
+            newCode = "if __package__ or "." in __name__:\n    from ._fastjet import FastJetError\n  else:\n    from _fastjet import FastJetError"
+            subprocess.run(["sed", "-i", "-E", f"'s/{oldCode}/{newCode}/g'", "pyinterface/fastjet.i"], cwd=FASTJET, check=True)
+
             env = os.environ.copy()
             env["PYTHON"] = sys.executable
             env["PYTHON_INCLUDE"] = f'-I{sysconfig.get_path("include")}'

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 zip_obj.extractall(DIR)
 
             # Patch for FastJet core version 3.4.0
-            # To be removed when it is applied upstream
+            # To be removed when https://gitlab.com/fastjet/fastjet/-/merge_requests/1 is merged upstream
             subprocess.run(
-                ["sed", "-i", "-E", "-f", DIR / "patch.sed", "pyinterface/fastjet.i"],
+                ["patch", "pyinterface/fastjet.i", DIR / "patch.txt"],
                 cwd=FASTJET,
             )
 

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                     f"'s/{oldCode}/{newCode}/g'", 
                     "pyinterface/fastjet.i"
                 ], 
-                cwd=FASTJET, 
-                check=True
+                cwd=FASTJET
             )
 
             env = os.environ.copy()

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             # Patch for FastJet core version 3.4.0
             # To be removed when it is applied upstream
             oldCode = "from _fastjet import FastJetError"
-            newCode = "if __package__ or "." in __name__:\n    from ._fastjet import FastJetError\n  else:\n    from _fastjet import FastJetError"
+            newCode = """if __package__ or "." in __name__:\n    from ._fastjet import FastJetError\n  else:\n    from _fastjet import FastJetError"""
             subprocess.run(["sed", "-i", "-E", f"'s/{oldCode}/{newCode}/g'", "pyinterface/fastjet.i"], cwd=FASTJET, check=True)
 
             env = os.environ.copy()

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,18 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             # Patch for FastJet core version 3.4.0
             # To be removed when it is applied upstream
             oldCode = "from _fastjet import FastJetError"
-            newCode = """if __package__ or "." in __name__:\n    from ._fastjet import FastJetError\n  else:\n    from _fastjet import FastJetError"""
-            subprocess.run(["sed", "-i", "-E", f"'s/{oldCode}/{newCode}/g'", "pyinterface/fastjet.i"], cwd=FASTJET, check=True)
+            newCode = 'if __package__ or "." in __name__:\n    from ._fastjet import FastJetError\n  else:\n    from _fastjet import FastJetError'
+            subprocess.run(
+                [
+                    "sed", 
+                    "-i", 
+                    "-E", 
+                    f"'s/{oldCode}/{newCode}/g'", 
+                    "pyinterface/fastjet.i"
+                ], 
+                cwd=FASTJET, 
+                check=True
+            )
 
             env = os.environ.copy()
             env["PYTHON"] = sys.executable

--- a/setup.py
+++ b/setup.py
@@ -55,17 +55,9 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
 
             # Patch for FastJet core version 3.4.0
             # To be removed when it is applied upstream
-            oldCode = "from _fastjet import FastJetError"
-            newCode = 'if __package__ or "." in __name__:\n    from ._fastjet import FastJetError\n  else:\n    from _fastjet import FastJetError'
             subprocess.run(
-                [
-                    "sed", 
-                    "-i", 
-                    "-E", 
-                    f"'s/{oldCode}/{newCode}/g'", 
-                    "pyinterface/fastjet.i"
-                ], 
-                cwd=FASTJET
+                ["sed", "-i", "-E", "-f", DIR / "patch.sed", "pyinterface/fastjet.i"],
+                cwd=FASTJET,
             )
 
             env = os.environ.copy()

--- a/src/fastjet/version.py
+++ b/src/fastjet/version.py
@@ -2,7 +2,7 @@
 
 import re
 
-__version__ = "3.3.4.0rc10"
+__version__ = "3.4.0.0rc1"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
This PR is introducing FastJet core version 3.4.0 (the latest stable out). As I have described in the comments in PR #68, the introduction of `FastJetError` makes the swig-generated code not importable for us. Therefore a patch is needed for the moment in the swig description file. I am using sed to apply the patch but I am open to other better approaches. I have already opened an [upstream merge request](https://gitlab.com/fastjet/fastjet/-/merge_requests/1) that would solve this in a better way. I am not sure when and if this will get merged, but once it does then we can remove the patch. I would also like to make a new release soon (I believe that would be 3.4.0.0rc1) because I need to get some of the recent updates to my work areas. Are there any objections to this? 