### PR TITLE
fj-contrib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "pybind11"]
 	path = pybind11
 	url = https://github.com/pybind/pybind11.git
+[submodule "fastjet-contrib"]
+	path = fastjet-contrib
+	url = https://github.com/cms-externals/fastjet-contrib.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 graft src
 graft tests
 graft fastjet-core
+graft fastjet-contrib
 graft pybind11
 global-exclude .git .gitmodules
 include LICENSE README.md pyproject.toml setup.py setup.cfg patch_fastjet_i.txt patch_clustersequence.txt

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,14 @@ FASTJET_CONTRIB = DIR / "fastjet-contrib"
 PYTHON = DIR / "src/fastjet"
 OUTPUT = PYTHON / "_fastjet_core"
 
-LIBS = ["fastjet", "fastjettools", "siscone", "siscone_spherical", "fastjetplugins"]
+LIBS = [
+    "fastjet",
+    "fastjettools",
+    "siscone",
+    "siscone_spherical",
+    "fastjetplugins",
+    "fastjetcontribfragile",
+]
 
 
 def get_version() -> str:
@@ -107,6 +114,15 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             subprocess.run(["make", "-j"], cwd=FASTJET_CONTRIB, env=env, check=True)
             subprocess.run(
                 ["make", "install"], cwd=FASTJET_CONTRIB, env=env, check=True
+            )
+            subprocess.run(
+                ["make", "fragile-shared"], cwd=FASTJET_CONTRIB, env=env, check=True
+            )
+            subprocess.run(
+                ["make", "fragile-shared-install"],
+                cwd=FASTJET_CONTRIB,
+                env=env,
+                check=True,
             )
 
         setuptools.command.build_ext.build_ext.build_extensions(self)

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ CGAL_ZIP = (
 
 DIR = pathlib.Path(__file__).parent.resolve()
 FASTJET = DIR / "fastjet-core"
+FASTJET_CONTRIB = DIR / "fastjet-contrib"
 PYTHON = DIR / "src/fastjet"
 OUTPUT = PYTHON / "_fastjet_core"
 
@@ -96,6 +97,17 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
             env["ORIGIN"] = "$ORIGIN"  # if evaluated, it will still be '$ORIGIN'
             subprocess.run(["make", "-j"], cwd=FASTJET, env=env, check=True)
             subprocess.run(["make", "install"], cwd=FASTJET, env=env, check=True)
+
+            subprocess.run(
+                ["./configure", f"--fastjet-config={FASTJET}/fastjet-config"],
+                cwd=FASTJET_CONTRIB,
+                env=env,
+                check=True,
+            )
+            subprocess.run(["make", "-j"], cwd=FASTJET_CONTRIB, env=env, check=True)
+            subprocess.run(
+                ["make", "install"], cwd=FASTJET_CONTRIB, env=env, check=True
+            )
 
         setuptools.command.build_ext.build_ext.build_extensions(self)
 

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -1591,6 +1591,7 @@ PYBIND11_MODULE(_ext, m) {
         }
         jk++;
 
+        auto lund_generator = fastjet::contrib::LundGenerator();
         std::vector<double> Delta_vec;
         std::vector<double> kt_vec;
 
@@ -1618,7 +1619,6 @@ PYBIND11_MODULE(_ext, m) {
           auto prev = ptrjetoffsets[jetidx-1];
 
           for (unsigned int j = 0; j < jets.size(); j++){
-            auto lund_generator = fastjet::contrib::LundGenerator();
             auto lund_result = lund_generator.result(jets[j]);
             auto splittings = lund_result.size();
             for (unsigned int k = 0; k < splittings; k++){

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -13,6 +13,7 @@
 #include <fastjet/GhostedAreaSpec.hh>
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
+#include <fastjet/contrib/LundGenerator.hh>
 
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
@@ -1617,17 +1618,12 @@ PYBIND11_MODULE(_ext, m) {
           auto prev = ptrjetoffsets[jetidx-1];
 
           for (unsigned int j = 0; j < jets.size(); j++){
-            // adapted from https://github.com/fdreyer/LundPlane/blob/master/LundGenerator.cc
-            PseudoJet pair, j1, j2;
-            pair = jets[j];
-            int splittings = 0;
-            while (pair.has_parents(j1, j2)) {
-              if (j1.pt2() < j2.pt2()) std::swap(j1,j2);
-              double Delta = j1.delta_R(j2);
-              Delta_vec.push_back(Delta);
-              kt_vec.push_back(j2.pt() * Delta);
-              pair = j1;
-              splittings++;
+            auto lund_generator = fastjet::contrib::LundGenerator();
+            auto lund_result = lund_generator.result(jets[j]);
+            auto splittings = lund_result.size();
+            for (unsigned int k = 0; k < splittings; k++){
+              Delta_vec.push_back(lund_result[k].Delta());
+              kt_vec.push_back(lund_result[k].kt());
             }
 
             ptrjetoffsets[jetidx] = splittings + prev;


### PR DESCRIPTION
- [x] Add `fastjet-contrib` as a submodule
- [x] Compile `fastjet-contrib` as part of `setup.py`as a submodule
- [x] Reuse `LundPlane` code from `fastjet-contrib`
- [x] Check if it runs/passes tests

This approach adds some overhead (compiling all of `fastjet-contrib`), but in principle allows us to add helper functions to use other contributions like SoftDrop, Nsubjettiness, EnergyCorrelationFunctions, etc.