### PR TITLE
Fix for swig 4.1.X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
   push:
     branches:
-    - master
-    - main
-    - develop
+      - master
+      - main
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,14 +18,14 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - uses: actions/setup-python@v4
-    - uses: pre-commit/action@v3.0.0
-      with:
-        extra_args: --hook-stage manual --all-files
+      - uses: actions/setup-python@v4
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --hook-stage manual --all-files
 
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
@@ -33,56 +33,55 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11']
-        runs-on: [ubuntu-latest]   # , macos-latest
+        python-version: ["3.7", "3.11"]
+        runs-on: [ubuntu-latest] # , macos-latest
 
         # include:
         # - python-version: pypy-3.8
         #   runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install compiler tools on macOS
-      if: runner.os == 'macOS'
-      run: brew install automake swig gmp mpfr boost
+      - name: Install compiler tools on macOS
+        if: runner.os == 'macOS'
+        run: brew install automake swig gmp mpfr boost
 
-    - name: Install extra deps on Linux
-      if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool
+      - name: Install extra deps on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool
 
-    - name: Install package
-      run: python -m pip install '.[test]' -v
+      - name: Install package
+        run: python -m pip install '.[test]' -v
 
-    - name: Test package
-      run: python -m pytest -vv -rs -Wd
+      - name: Test package
+        run: python -m pytest -vv -rs -Wd
 
   test_wheels:
     name: Wheel on Linux
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - uses: pypa/cibuildwheel@v2.11.2
-      env:
-        CIBW_ARCHS: auto64
-        CIBW_BUILD: cp311-*
-        CIBW_BUILD_VERBOSITY: 2
+      - uses: pypa/cibuildwheel@v2.11.3
+        env:
+          CIBW_ARCHS: auto64
+          CIBW_BUILD: cp311-*
+          CIBW_BUILD_VERBOSITY: 2
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        path: wheelhouse/*.whl
-
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse/*.whl
 
   pass:
     needs: [pre-commit, checks, test_wheels]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,16 +11,16 @@ jobs:
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - name: Build SDist
-      run: pipx run build --sdist
+      - name: Build SDist
+        run: pipx run build --sdist
 
-    - uses: actions/upload-artifact@v3
-      with:
-        path: dist/*.tar.gz
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
 
   build_wheels:
     name: Make ${{ matrix.python-build-version }} ${{ matrix.os }} Wheels
@@ -28,44 +28,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-build-version: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
-        os: [ubuntu-latest]   # , macos-latest
+        python-build-version:
+          ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+        os: [ubuntu-latest] # , macos-latest
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - name: Install compiler tools on macOS
-      if: runner.os == 'macOS'
-      run: brew install automake
+      - name: Install compiler tools on macOS
+        if: runner.os == 'macOS'
+        run: brew install automake
 
-    - uses: pypa/cibuildwheel@v2.11.2
-      env:
-        CIBW_ARCHS: auto64
-        CIBW_BUILD: ${{ matrix.python-build-version }}
-        CIBW_BUILD_VERBOSITY: 2
+      - uses: pypa/cibuildwheel@v2.11.3
+        env:
+          CIBW_ARCHS: auto64
+          CIBW_BUILD: ${{ matrix.python-build-version }}
+          CIBW_BUILD_VERBOSITY: 2
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        path: wheelhouse/*.whl
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse/*.whl
 
   test_sdist:
     needs: [make_sdist]
     runs-on: ubuntu-latest
     steps:
-    - uses : actions/download-artifact@v3
-      with:
-        name: artifact
-        path: dist/
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist/
 
-    - name: Install extra deps on Linux
-      if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool
+      - name: Install extra deps on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool
 
-    - name: test sdist
-      run: python -m pip install dist/*.tar.gz
+      - name: test sdist
+        run: python -m pip install dist/*.tar.gz
 
   upload_all:
     needs: [build_wheels, make_sdist]
@@ -73,13 +74,13 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: artifact
-        path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
 
-    - uses: pypa/gh-action-pypi-publish@v1.6.4
-      with:
-        user: __token__
-        # Remember to generate this and set it in "GitHub Secrets"
-        password: ${{ secrets.pypi_password }}
+      - uses: pypa/gh-action-pypi-publish@v1.6.4
+        with:
+          user: __token__
+          # Remember to generate this and set it in "GitHub Secrets"
+          password: ${{ secrets.pypi_password }}

--- a/src/fastjet/__init__.py
+++ b/src/fastjet/__init__.py
@@ -21,9 +21,6 @@ from fastjet._swig import Boost  # noqa: F401, E402
 from fastjet._swig import CASubJetTagger  # noqa: F401, E402
 from fastjet._swig import CASubJetTaggerStructure  # noqa: F401, E402
 from fastjet._swig import ClusterSequence1GhostPassiveArea  # noqa: F401, E402
-from fastjet._swig import ClusterSequence_fastjet_banner_stream  # noqa: F401, E402
-from fastjet._swig import ClusterSequence_print_banner  # noqa: F401, E402
-from fastjet._swig import ClusterSequence_set_fastjet_banner_stream  # noqa: F401, E402
 from fastjet._swig import ClusterSequenceActiveArea  # noqa: F401, E402
 from fastjet._swig import ClusterSequenceActiveAreaExplicitGhosts  # noqa: F401, E402
 from fastjet._swig import ClusterSequenceArea  # noqa: F401, E402
@@ -34,9 +31,6 @@ from fastjet._swig import ClusterSequenceVoronoiArea  # noqa: F401, E402
 from fastjet._swig import CompositeJetStructure  # noqa: F401, E402
 from fastjet._swig import E_scheme  # noqa: F401, E402
 from fastjet._swig import Error  # noqa: F401, E402
-from fastjet._swig import Error_set_default_stream  # noqa: F401, E402
-from fastjet._swig import Error_set_print_backtrace  # noqa: F401, E402
-from fastjet._swig import Error_set_print_errors  # noqa: F401, E402
 from fastjet._swig import Et2_scheme  # noqa: F401, E402
 from fastjet._swig import Et_scheme  # noqa: F401, E402
 from fastjet._swig import Filter  # noqa: F401, E402
@@ -51,15 +45,10 @@ from fastjet._swig import JetDefinition  # noqa: F401, E402
 from fastjet._swig import JetDefinition0Param  # noqa: F401, E402
 from fastjet._swig import JetDefinition1Param  # noqa: F401, E402
 from fastjet._swig import JetDefinition2Param  # noqa: F401, E402
-from fastjet._swig import JetDefinition_algorithm_description  # noqa: F401, E402
-from fastjet._swig import JetDefinition_n_parameters_for_algorithm  # noqa: F401, E402
 from fastjet._swig import JetMedianBackgroundEstimator  # noqa: F401, E402
 from fastjet._swig import JHTopTagger  # noqa: F401, E402
 from fastjet._swig import JHTopTaggerStructure  # noqa: F401, E402
 from fastjet._swig import LimitedWarning  # noqa: F401, E402
-from fastjet._swig import LimitedWarning_set_default_max_warn  # noqa: F401, E402
-from fastjet._swig import LimitedWarning_set_default_stream  # noqa: F401, E402
-from fastjet._swig import LimitedWarning_summary  # noqa: F401, E402
 from fastjet._swig import MassDropTagger  # noqa: F401, E402
 from fastjet._swig import MassDropTaggerStructure  # noqa: F401, E402
 from fastjet._swig import MaxRap  # noqa: F401, E402


### PR DESCRIPTION
Swig 4.1.X changed the way it handles functions with `@staticmethod`. Up to version 4.0.2 it used to produce an additional flat-named function for each static method. For example, the function `ClusterSequence.fastjet_banner_stream()` used to also have a flat-name counterpart: `ClusterSequence_fastjet_banner_stream()`. Now, this is gone. 

More info here https://github.com/swig/swig/pull/2137

I just removed those imports. Tests seem to be fine and I couldn't find any uses for them. 