### PR TITLE
Test `aarch64` wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,16 +78,14 @@ jobs:
           submodules: recursive
 
       - uses: uraimo/run-on-arch-action@v2.5.0
-        name: Build artifact
-        id: build
+        name: Run test in image
         with:
           arch: ${{ matrix.arch }}
           distro: ubuntu_latest
           # Not required, but speeds up builds
           githubToken: ${{ github.token }}
           dockerRunArgs: |
-            --volume "${PWD}:/fastjet"
-          shell: /bin/sh
+            --volume "${PWD}:/fastjet"  --platform linux/arm64/v8
           install: |
             uname -m
             add-apt-repository ppa:deadsnakes/ppa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,15 @@ jobs:
       - uses: uraimo/run-on-arch-action@v2.5.0
         name: Install and test in image
         with:
+          # workaround for https://github.com/uraimo/run-on-arch-action/issues/55
+          env: |
+            GITHUB_WORKFLOW: ${{ github.workflow }}-python${{ matrix.python-version }}
           arch: ${{ matrix.arch }}
           distro: ubuntu_latest
           # Not required, but speeds up builds
           githubToken: ${{ github.token }}
           dockerRunArgs: |
-            --volume "${PWD}:/fastjet" --platform linux/arm64
+            --volume "${PWD}:/fastjet" --platform linux/arm64 --workdir /fastjet
           install: |
             uname -m
             apt-get update
@@ -96,11 +99,11 @@ jobs:
             apt-get update
             apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-distutils python${{ matrix.python-version }}-venv
             python${{ matrix.python-version }} -m ensurepip
+            echo $PATH
+            echo $PWD
           run: |
             uname -m
             echo $PATH
-            echo $PWD
-            cd /fastjet
             echo $PWD
             python${{ matrix.python-version }} -m pip install '.[test]' -v
             python${{ matrix.python-version }} -m pytest -vv -rs -Wd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,14 @@ jobs:
       matrix:
         python-version: ["3.7", "3.11"]
         runs-on: [ubuntu-latest, macos-latest]
-
-        # include:
-        # - python-version: pypy-3.8
-        #   runs-on: ubuntu-latest
-
+        arch: [x86_64]
+        include:
+          - python-version: "3.7"
+            runs-on: ubuntu-latest
+            arch: arm64
+          - python-version: "3.11"
+            runs-on: ubuntu-latest
+            arch: arm64
     steps:
       - uses: actions/checkout@v3
         with:
@@ -48,6 +51,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - uses: docker/setup-qemu-action@v2.1.0
+        if: matrix.arch != 'x86_64'
+        with:
+         platforms: ${{ matrix.arch }}
 
       - name: Install compiler tools on macOS
         if: runner.os == 'macOS'
@@ -99,38 +107,8 @@ jobs:
         with:
           path: wheelhouse/*.whl
 
-  test_alt_wheels:
-    name: "Wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python: [311]
-        arch: [aarch64]
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - uses: docker/setup-qemu-action@v2.1.0
-        with:
-         platforms: arm64
-
-      - uses: pypa/cibuildwheel@v2.11.3
-        env:
-          CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: cp${{ matrix.python }}-*
-          CIBW_BUILD_VERBOSITY: 2
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v3
-        with:
-          path: wheelhouse/*.whl
-
   pass:
-    needs: [pre-commit, checks, test_wheels, test_alt_wheels]
+    needs: [pre-commit, checks, test_wheels]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All jobs passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
             --volume "${PWD}:/fastjet"  --platform linux/arm64/v8
           install: |
             uname -m
+            apt-get update
+            apt-get install -y software-properties-common
             add-apt-repository ppa:deadsnakes/ppa
             apt-get update
             apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version}} python3-pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,14 @@ jobs:
           submodules: recursive
 
       - uses: uraimo/run-on-arch-action@v2.5.0
-        name: Run test in image
+        name: Install and test in image
         with:
           arch: ${{ matrix.arch }}
           distro: ubuntu_latest
           # Not required, but speeds up builds
           githubToken: ${{ github.token }}
           dockerRunArgs: |
-            --volume "${PWD}:/fastjet"  --platform linux/arm64/v8
+            --volume "${PWD}:/fastjet" --platform linux/arm64
           install: |
             uname -m
             apt-get update
@@ -94,7 +94,7 @@ jobs:
             echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776
             apt-get update
-            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-distutils
+            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-distutils python${{ matrix.python-version }}-venv
             python${{ matrix.python-version }} -m ensurepip
           run: |
             uname -m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,22 +28,27 @@ jobs:
           extra_args: --hook-stage manual --all-files
 
   checks:
-    name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
+    name: Check Python ${{ matrix.python-version }}, ${{ matrix.arch }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.11"]
         runs-on: [ubuntu-latest, macos-latest]
-        arch: [x86_64]
+        arch: [auto64]
         include:
           - python-version: "3.7"
             runs-on: ubuntu-latest
-            arch: arm64
+            arch: aarch64
           - python-version: "3.11"
             runs-on: ubuntu-latest
-            arch: arm64
+            arch: aarch64
     steps:
+      - uses: docker/setup-qemu-action@v2.1.0
+        if: matrix.arch != 'auto64'
+        with:
+         platforms: arm64
+
       - uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -51,11 +56,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - uses: docker/setup-qemu-action@v2.1.0
-        if: matrix.arch != 'x86_64'
-        with:
-         platforms: ${{ matrix.arch }}
 
       - name: Install compiler tools on macOS
         if: runner.os == 'macOS'
@@ -89,6 +89,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+
+      - uses: docker/setup-qemu-action@v2.1.0
+        if: matrix.arch != 'auto64'
+        with:
+         platforms: all
 
       - name: Install compiler tools on macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,14 @@ jobs:
         run: python -m pytest -vv -rs -Wd
 
   test_wheels:
-    name: "Wheel on ${{ matrix.os }}"
+    name: "Wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        python: [311]
+        arch: [auto64]
 
     steps:
       - uses: actions/checkout@v3
@@ -88,8 +90,36 @@ jobs:
 
       - uses: pypa/cibuildwheel@v2.11.4
         env:
-          CIBW_ARCHS: auto64
-          CIBW_BUILD: cp311-*
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: cp${{ matrix.python }}-*
+          CIBW_BUILD_VERBOSITY: 2
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse/*.whl
+
+  test_alt_wheels:
+    name: "Wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python: [311]
+        arch: [aarch64]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: docker/setup-qemu-action@v2.1.0
+
+      - uses: pypa/cibuildwheel@v2.11.3
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: cp${{ matrix.python }}-*
           CIBW_BUILD_VERBOSITY: 2
 
       - name: Upload wheels
@@ -98,7 +128,7 @@ jobs:
           path: wheelhouse/*.whl
 
   pass:
-    needs: [pre-commit, checks, test_wheels]
+    needs: [pre-commit, checks, test_wheels, test_alt_wheels]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All jobs passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
             apt-get install -y ca-certificates
             echo 'deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
+            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776
             apt-get update
             apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python3-pip
           run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
             echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776
             apt-get update
-            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python3-pip
+            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python${{ matrix.python-version }}-distutils python3-pip
           run: |
             uname -m
             echo $PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,18 +88,20 @@ jobs:
             --volume "${PWD}:/fastjet"  --platform linux/arm64/v8
           install: |
             uname -m
+            apt-get update
+            apt-get install -y ca-certificates
             echo 'deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             apt-get update
-            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version}} python3-pip
+            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python3-pip
           run: |
             uname -m
             echo $PATH
             echo $PWD
             cd /fastjet
             echo $PWD
-            python${{ matrix.python-version}} -m pip install '.[test]' -v
-            python${{ matrix.python-version}} -m pytest -vv -rs -Wd
+            python${{ matrix.python-version }} -m pip install '.[test]' -v
+            python${{ matrix.python-version }} -m pytest -vv -rs -Wd
 
   test_wheels:
     name: "Wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,25 +92,21 @@ jobs:
           install: |
             uname -m
             apt-get update
-            apt-get install -y ca-certificates gnupg2 build-essential patch
+            apt-get -y install --no-install-recommends ca-certificates gnupg2 build-essential libboost-dev libmpfr-dev swig patch automake autoconf libtool
             echo 'deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776
             apt-get update
-            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-distutils python${{ matrix.python-version }}-venv
-            python${{ matrix.python-version }} -m ensurepip --upgrade
-            echo $PATH
-            echo $PWD
-            echo $LD_LIBRARY_PATH
-            ls /usr/local/include/python${{ matrix.python-version }}
+            apt-get -y install --no-install-recommends python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-distutils python${{ matrix.python-version }}-venv
+            python${{ matrix.python-version }} -m venv /venv
           run: |
             uname -m
-            echo $PATH
-            echo $PWD
-            echo $LD_LIBRARY_PATH
-            ls /usr/local/include/python${{ matrix.python-version }}
-            python${{ matrix.python-version }} -m pip install '.[test]' -v
-            python${{ matrix.python-version }} -m pytest -vv -rs -Wd
+            echo "PATH: ${PATH}"
+            echo "PWD: ${PWD}"
+            . /venv/bin/activate
+            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install '.[test]' -v
+            pytest -vv -rs -Wd
 
   test_wheels:
     name: "Wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           install: |
             uname -m
             apt-get update
-            apt-get install -y ca-certificates
+            apt-get install -y ca-certificates gnupg2
             echo 'deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,19 +36,7 @@ jobs:
         python-version: ["3.7", "3.11"]
         runs-on: [ubuntu-latest, macos-latest]
         arch: [auto64]
-        include:
-          - python-version: "3.7"
-            runs-on: ubuntu-latest
-            arch: aarch64
-          - python-version: "3.11"
-            runs-on: ubuntu-latest
-            arch: aarch64
     steps:
-      - uses: docker/setup-qemu-action@v2.1.0
-        if: matrix.arch != 'auto64'
-        with:
-         platforms: arm64
-
       - uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -74,6 +62,45 @@ jobs:
 
       - name: Test package
         run: python -m pytest -vv -rs -Wd
+
+  checks_alt:
+    name: Check Python ${{ matrix.python-version }}, ${{ matrix.arch }} on ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.11"]
+        runs-on: [ubuntu-latest]
+        arch: [aarch64]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: uraimo/run-on-arch-action@v2
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.runs-on }}
+          # Not required, but speeds up builds
+          githubToken: ${{ github.token }}
+          dockerRunArgs: |
+            --volume "${PWD}:/fastjet"
+          shell: /bin/sh
+          install: |
+            uname -m
+            add-apt-repository ppa:deadsnakes/ppa
+            apt-get update
+            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version}} python3-pip
+          run: |
+            uname -m
+            echo $PATH
+            echo $PWD
+            cd /fastjet
+            echo $PWD
+            python${{ matrix.python-version}} -m pip install '.[test]' -v
+            python${{ matrix.python-version}} -m pytest -vv -rs -Wd
 
   test_wheels:
     name: "Wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"
@@ -113,7 +140,7 @@ jobs:
           path: wheelhouse/*.whl
 
   pass:
-    needs: [pre-commit, checks, test_wheels]
+    needs: [pre-commit, checks, checks_alt, test_wheels]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All jobs passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           install: |
             uname -m
             echo 'deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
-            echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list            
+            echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             apt-get update
             apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version}} python3-pip
           run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
           submodules: recursive
 
       - uses: docker/setup-qemu-action@v2.1.0
+        with:
+         platforms: arm64
 
       - uses: pypa/cibuildwheel@v2.11.3
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,8 @@ jobs:
             echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
             apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776
             apt-get update
-            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python${{ matrix.python-version }}-distutils python3-pip
+            apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-distutils
+            python${{ matrix.python-version }} -m ensurepip
           run: |
             uname -m
             echo $PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,12 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@v2.5.0
         name: Build artifact
         id: build
         with:
           arch: ${{ matrix.arch }}
-          distro: ${{ matrix.runs-on }}
+          distro: ubuntu_latest
           # Not required, but speeds up builds
           githubToken: ${{ github.token }}
           dockerRunArgs: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,8 @@ jobs:
             --volume "${PWD}:/fastjet"  --platform linux/arm64/v8
           install: |
             uname -m
-            apt-get update
-            apt-get install -y software-properties-common
-            add-apt-repository ppa:deadsnakes/ppa
+            echo 'deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
+            echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list            
             apt-get update
             apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool python${{ matrix.python-version}} python3-pip
           run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -70,6 +70,8 @@ jobs:
           submodules: recursive
 
       - uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: arm64
 
       - uses: pypa/cibuildwheel@v2.11.3
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,14 +23,14 @@ jobs:
           path: dist/*.tar.gz
 
   build_wheels:
-    name: Make ${{ matrix.python-build-version }} ${{ matrix.os }} Wheels
+    name: "Build wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-build-version:
-          ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+        python: [37, 38, 39, 310, 311]
         os: [ubuntu-latest, macos-latest]
+        arch: [auto64]
 
     steps:
       - uses: actions/checkout@v3
@@ -45,8 +45,36 @@ jobs:
 
       - uses: pypa/cibuildwheel@v2.11.4
         env:
-          CIBW_ARCHS: auto64
-          CIBW_BUILD: ${{ matrix.python-build-version }}
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: cp${{ matrix.python }}-*
+          CIBW_BUILD_VERBOSITY: 2
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          path: wheelhouse/*.whl
+
+  build_alt_wheels:
+    name: "Build wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python: [37, 38, 39, 310, 311]
+        arch: [aarch64]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: docker/setup-qemu-action@v2.1.0
+
+      - uses: pypa/cibuildwheel@v2.11.3
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: cp${{ matrix.python }}-*
           CIBW_BUILD_VERBOSITY: 2
 
       - name: Upload wheels
@@ -71,7 +99,7 @@ jobs:
         run: python -m pip install dist/*.tar.gz
 
   upload_all:
-    needs: [build_wheels, make_sdist]
+    needs: [build_wheels, build_alt_wheels, make_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,8 +31,29 @@ jobs:
         python: [37, 38, 39, 310, 311]
         os: [ubuntu-latest, macos-latest]
         arch: [auto64]
+        include:
+          - python: 37
+            runs-on: ubuntu-latest
+            arch: aarch64
+          - python: 38
+            runs-on: ubuntu-latest
+            arch: aarch64
+          - python: 39
+            runs-on: ubuntu-latest
+            arch: aarch64
+          - python: 310
+            runs-on: ubuntu-latest
+            arch: aarch64
+          - python: 311
+            runs-on: ubuntu-latest
+            arch: aarch64
 
     steps:
+      - uses: docker/setup-qemu-action@v2.1.0
+        if: matrix.arch != 'auto64'
+        with:
+         platforms: arm64
+
       - uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -44,36 +65,6 @@ jobs:
           export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
 
       - uses: pypa/cibuildwheel@v2.11.4
-        env:
-          CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: cp${{ matrix.python }}-*
-          CIBW_BUILD_VERBOSITY: 2
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v3
-        with:
-          path: wheelhouse/*.whl
-
-  build_alt_wheels:
-    name: "Build wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python: [37, 38, 39, 310, 311]
-        arch: [aarch64]
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - uses: docker/setup-qemu-action@v2.1.0
-        with:
-          platforms: arm64
-
-      - uses: pypa/cibuildwheel@v2.11.3
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: cp${{ matrix.python }}-*
@@ -101,7 +92,7 @@ jobs:
         run: python -m pip install dist/*.tar.gz
 
   upload_all:
-    needs: [build_wheels, build_alt_wheels, make_sdist]
+    needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 

--- a/tests/test_002-exclusive_jets.py
+++ b/tests/test_002-exclusive_jets.py
@@ -107,15 +107,20 @@ def test_exclusive_lund_declustering_single():
 
     lds = cluster.exclusive_jets_lund_declusterings(2)
 
-    lund_declustering_output = [
+    # expected output from x86_64, aarch64 is slightly different
+    lund_declustering_output = ak.Array(
         [
-            {"Delta": 0.08755181299980186, "kt": 0.30179987478357223},
-            {"Delta": 0.019481226884377707, "kt": 0.06602095529127928},
-        ],
-        [{"Delta": 0.014750342295225208, "kt": 1.0480537658466145}],
-    ]
+            [
+                {"Delta": 0.08755181299980186, "kt": 0.30179987478357223},
+                {"Delta": 0.019481226884377707, "kt": 0.06602095529127928},
+            ],
+            [{"Delta": 0.014750342295225208, "kt": 1.0480537658466145}],
+        ]
+    )
 
-    assert lund_declustering_output == lds.to_list()
+    is_close = ak.ravel(ak.isclose(lund_declustering_output, lds, rtol=1e-12, atol=0))
+
+    assert ak.all(is_close)
 
 
 def test_exclusive_lund_declustering_multi():
@@ -144,24 +149,29 @@ def test_exclusive_lund_declustering_multi():
 
     lds = cluster.exclusive_jets_lund_declusterings(2)
 
-    lund_declustering_output = [
+    # expected output from x86_64, aarch64 is slightly different
+    lund_declustering_output = ak.Array(
         [
             [
-                {"Delta": 0.08755181299980186, "kt": 0.30179987478357223},
-                {"Delta": 0.019481226884377707, "kt": 0.06602095529127928},
+                [
+                    {"Delta": 0.08755181299980186, "kt": 0.30179987478357223},
+                    {"Delta": 0.019481226884377707, "kt": 0.06602095529127928},
+                ],
+                [{"Delta": 0.014750342295225208, "kt": 1.0480537658466145}],
             ],
-            [{"Delta": 0.014750342295225208, "kt": 1.0480537658466145}],
-        ],
-        [
             [
-                {"Delta": 0.08755181299980186, "kt": 0.30179987478357223},
-                {"Delta": 0.019481226884377707, "kt": 0.06602095529127928},
+                [
+                    {"Delta": 0.08755181299980186, "kt": 0.30179987478357223},
+                    {"Delta": 0.019481226884377707, "kt": 0.06602095529127928},
+                ],
+                [{"Delta": 0.014750342295225208, "kt": 1.0480537658466145}],
             ],
-            [{"Delta": 0.014750342295225208, "kt": 1.0480537658466145}],
-        ],
-    ]
+        ]
+    )
 
-    assert lund_declustering_output == lds.to_list()
+    is_close = ak.ravel(ak.isclose(lund_declustering_output, lds, rtol=1e-12, atol=0))
+
+    assert ak.all(is_close)
 
 
 def test_exclusive_constituents_multi():


### PR DESCRIPTION
Addresses #165.

Building `aarch64` wheels with QEMU does indeed take a while (~1 hour 30 min) as noted by @lgray, so a self-hosted runner or separate CI would be better long term.

<s>Also @rkansal47, there is a minor numerical difference for the Lund clustering that required changing the test from checking for equality to closeness. Interestingly, this is the only test that requires this. You can see the numerical difference in the first failing CI check. I presume this is ok, but do you have any thoughts about why it happens here?</s> I agree with @henryiii that we should probably be using `ak.isclose()` with an appropriate tolerance for all tests anyway.