### PR TITLE
ci: Add Cirrus CI config for aarch64 build tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,44 @@
+task:
+  only_if: $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH == 'develop' || $CIRRUS_TAG != '' || $CIRRUS_PR != ''
+  env:
+    CIRRUS_CLONE_SUBMODULES: true
+
+  matrix:
+    - name: Test build
+
+      # Default is 2 CPUs and 4 GB of memory
+      arm_container:
+        cpu: 4
+        memory: 6G
+        matrix:
+          - image: python:3.7
+          - image: python:3.11
+
+      install_build_dependencies_script: |
+        apt-get update
+        apt-get -qq -y install --no-install-recommends \
+          gcc \
+          g++ \
+          libboost-dev \
+          libmpfr-dev \
+          libgmp-dev \
+          swig \
+          autoconf \
+          libtool \
+          patch \
+          automake
+
+      create_venv_script: |
+        python -m venv ../venv
+
+      install_script: |
+        . ../venv/bin/activate
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --verbose .
+        python -m pip list
+
+      pytest_script: |
+        . ../venv/bin/activate
+        python -m pip install --upgrade pytest
+        python -m pip list
+        pytest -vv -rs -Wd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,51 +63,6 @@ jobs:
       - name: Test package
         run: python -m pytest -vv -rs -Wd
 
-  checks_alt:
-    name: Check Python ${{ matrix.python-version }}, ${{ matrix.arch }} on ${{ matrix.runs-on }}
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.7", "3.11"]
-        runs-on: [ubuntu-latest]
-        arch: [aarch64]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - uses: uraimo/run-on-arch-action@v2.5.0
-        name: Install and test in image
-        with:
-          # workaround for https://github.com/uraimo/run-on-arch-action/issues/55
-          env: |
-            GITHUB_WORKFLOW: ${{ github.workflow }}-python${{ matrix.python-version }}
-          arch: ${{ matrix.arch }}
-          distro: ubuntu_latest
-          # Not required, but speeds up builds
-          githubToken: ${{ github.token }}
-          dockerRunArgs: |
-            --volume "${PWD}:/fastjet" --platform linux/arm64 --workdir /fastjet
-          install: |
-            uname -m
-            apt-get update
-            apt-get -y install --no-install-recommends ca-certificates gnupg2 build-essential libboost-dev libmpfr-dev swig patch automake autoconf libtool
-            echo 'deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
-            echo 'deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main' >> /etc/apt/sources.list
-            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776
-            apt-get update
-            apt-get -y install --no-install-recommends python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python${{ matrix.python-version }}-distutils python${{ matrix.python-version }}-venv
-            python${{ matrix.python-version }} -m venv /venv
-          run: |
-            uname -m
-            echo "PATH: ${PATH}"
-            echo "PWD: ${PWD}"
-            . /venv/bin/activate
-            python -m pip install --upgrade pip setuptools wheel
-            python -m pip install '.[test]' -v
-            pytest -vv -rs -Wd
-
   test_wheels:
     name: "Wheel: ${{ matrix.python }}, ${{ matrix.arch }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -146,7 +101,7 @@ jobs:
           path: wheelhouse/*.whl
 
   pass:
-    needs: [pre-commit, checks, checks_alt, test_wheels]
+    needs: [pre-commit, checks, test_wheels]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All jobs passed"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ graft fastjet-contrib
 graft pybind11
 global-exclude .git .gitmodules
 include LICENSE README.md pyproject.toml setup.py setup.cfg patch_fastjet_i.txt patch_clustersequence.txt
+exclude .cirrus.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://raw.githubusercontent.com/scikit-hep/fastjet/main/docs/logo.svg">
 
 [![Actions Status][actions-badge]][actions-link]
+[![cirrus-ci Status][cirrus-ci-badge]][cirrus-ci-link]
 [![PyPI version][pypi-version]][pypi-link]
 [![Conda-Forge][conda-badge]][conda-link]
 
@@ -13,6 +14,8 @@
 
 [actions-badge]:            https://github.com/scikit-hep/fastjet/workflows/CI/badge.svg
 [actions-link]:             https://github.com/scikit-hep/fastjet/actions
+[cirrus-ci-badge]:          https://api.cirrus-ci.com/github/scikit-hep/fastjet.svg?branch=main
+[cirrus-ci-link]:           https://cirrus-ci.com/github/scikit-hep/fastjet
 [conda-badge]:              https://img.shields.io/conda/vn/conda-forge/fastjet
 [conda-link]:               https://github.com/conda-forge/fastjet-feedstock
 [github-discussions-badge]: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github


### PR DESCRIPTION
# Description

* Follow up PR to PR #166 
* Add Cirrus CI config for aarch64 wheel tests.
* Exclude .cirrus.yml from MANIFEST.in.
* Remove QEMU based config for time.
* Add Cirrus CI badge to README.
   - [![cirrus-ci Status][cirrus-ci-badge]][cirrus-ci-link]

[cirrus-ci-badge]:          https://api.cirrus-ci.com/github/scikit-hep/fastjet.svg?branch=main
[cirrus-ci-link]:           https://cirrus-ci.com/github/scikit-hep/fastjet

## Suggested squash and merge commit message

```
* Add Cirrus CI config for aarch64 wheel tests.
   - The jobs take a large amount of memory and so modification
     of the default resources is needed.
* Exclude .cirrus.yml from MANIFEST.in.
* Remove GitHub Actions QUEM based aarch64 test. As the Cirrus CI takes minutes
 instead of over an hour there is now not a need for this test to run in
 GitHub Actions.
* Add Cirrus CI build status badge for the main branch to README.
```