### PR TITLE
enable thread safety by default in fastjet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
 
             args = [
                 f"--prefix={OUTPUT}",
+                "--enable-thread-safety",
                 "--disable-auto-ptr",
                 "--enable-allcxxplugins",
                 "--enable-cgal-header-only",


### PR DESCRIPTION
Turn on thread safety options so users don't run into nasty surprises using dask.