### PR TITLE
feat: Adding EnergyCorrelator from Contrib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     stages: [manual]
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: "v16.0.3"
+  rev: "v16.0.4"
   hooks:
     - id: clang-format
       types_or: [c++, c, cuda]

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -21,8 +21,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <iostream> //debugging
-
 namespace fj = fastjet;
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -14,6 +14,7 @@
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
 #include <fastjet/contrib/LundGenerator.hh>
+#include <fastjet/contrib/EnergyCorrelator.hh>
 
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
@@ -1579,6 +1580,76 @@ PYBIND11_MODULE(_ext, m) {
           None.
         Returns:
           pt, eta, phi, m of inclusive jets.
+      )pbdoc")
+      .def("to_numpy_energy_correlators",
+      [](const output_wrapper ow, const int n_jets = 0, const double beta = 1, double npoint = 0, int angles = 0, double alpha = 0, std::string func = "default") {
+        auto css = ow.cse;
+        int64_t len = css.size();
+        auto jk = 0;
+
+        for (int i = 0; i < len; i++){
+          jk += css[i]->exclusive_jets(n_jets).size();
+        }
+        jk++;
+
+        std::transform(func.begin(), func.end(), func.begin(),
+          [](unsigned char c){ return std::tolower(c); });
+        auto energy_correlator = std::shared_ptr<fastjet::FunctionOfPseudoJet<double>>(nullptr);
+        if ( func == "ratio" ) {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorRatio>(npoint, beta); }
+        else if ( func == "doubleratio" ) {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorDoubleRatio>(npoint, beta); }
+        else if ( func == "c1" ) {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorC1>(beta);}
+        else if ( func == "c2" ) {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorC2>(beta);}
+        else if ( func == "d2" ) {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorD2>(beta);}
+        else if ( func == "generalized" ) {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorGeneralized>(angles, npoint, beta);}
+        else if (func == "generalized2") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorGeneralizedD2>(alpha, beta);}
+        else if (func == "nseries") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorNseries>(npoint, beta);}
+        else if (func == "n2") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorN2>(beta);}
+        else if (func == "n3") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorN3>(beta);}
+        else if (func == "mseries") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorMseries>(npoint, beta);}
+        else if (func == "m2") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorM2>(beta);}
+        else if (func == "cseries") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorCseries>(npoint, beta);}
+        else if (func == "useries") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorUseries>(npoint, beta);}
+        else if (func == "u1") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorU1>(beta);}
+        else if (func == "u2") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorU2>(beta);}
+        else if (func == "u3") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorU3>(beta);}
+        else if (func == "default") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelator>(npoint, beta);}
+
+
+        std::vector<double> ECF_vec;
+
+        for (unsigned int i = 0; i < css.size(); i++){  // iterate through events
+          auto jets = css[i]->exclusive_jets(n_jets);
+          int size = css[i]->exclusive_jets(n_jets).size();
+
+          for (unsigned int j = 0; j < jets.size(); j++){
+            auto ecf_result = energy_correlator->result(jets[j]); //
+            ECF_vec.push_back(ecf_result);
+          }
+        }
+
+        auto ECF = py::array(ECF_vec.size(), ECF_vec.data());
+
+        return ECF;
+      }, R"pbdoc(
+        Calculates the energy correlators for each jet in each event.
       )pbdoc")
       .def("to_numpy_exclusive_njet_lund_declusterings",
       [](const output_wrapper ow, const int n_jets = 0) {

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -21,6 +21,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <iostream> //debugging
+
 namespace fj = fastjet;
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -1631,7 +1633,6 @@ PYBIND11_MODULE(_ext, m) {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorU3>(beta);}
         else if (func == "default") {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelator>(npoint, beta);}
-
 
         std::vector<double> ECF_vec;
 

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -1651,6 +1651,15 @@ PYBIND11_MODULE(_ext, m) {
         return ECF;
       }, R"pbdoc(
         Calculates the energy correlators for each jet in each event.
+        Args:
+          n_jets: number of exclusive subjets.
+          beta: beta parameter for energy correlators.
+          npoint: n-point specification for ECFGs. Also used to determine desired n-point function for all series classes.
+          angles: number of angles for generalized energy correlators.
+          alpha: alpha parameter for generalized D2.
+          func: energy correlator function to use.
+        Returns:
+          Energy correlators for each jet in each event.
       )pbdoc")
       .def("to_numpy_exclusive_njet_lund_declusterings",
       [](const output_wrapper ow, const int n_jets = 0) {

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -16,7 +16,6 @@
 #include <fastjet/contrib/EnergyCorrelator.hh>
 #include <fastjet/contrib/LundGenerator.hh>
 
-
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -13,8 +13,9 @@
 #include <fastjet/GhostedAreaSpec.hh>
 #include <fastjet/JetDefinition.hh>
 #include <fastjet/PseudoJet.hh>
-#include <fastjet/contrib/LundGenerator.hh>
 #include <fastjet/contrib/EnergyCorrelator.hh>
+#include <fastjet/contrib/LundGenerator.hh>
+
 
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -1584,7 +1584,7 @@ PYBIND11_MODULE(_ext, m) {
           pt, eta, phi, m of inclusive jets.
       )pbdoc")
       .def("to_numpy_energy_correlators",
-      [](const output_wrapper ow, const int n_jets = 0, const double beta = 1, double npoint = 0, int angles = 0, double alpha = 0, std::string func = "default") {
+      [](const output_wrapper ow, const int n_jets = 1, const double beta = 1, double npoint = 0, int angles = 0, double alpha = 0, std::string func = "generalized") {
         auto css = ow.cse;
         int64_t len = css.size();
 
@@ -1603,7 +1603,7 @@ PYBIND11_MODULE(_ext, m) {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorD2>(beta);}
         else if ( func == "generalized" ) {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorGeneralized>(angles, npoint, beta);}
-        else if (func == "generalized2") {
+        else if (func == "generalizedd2") {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorGeneralizedD2>(alpha, beta);}
         else if (func == "nseries") {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorNseries>(npoint, beta);}
@@ -1625,8 +1625,8 @@ PYBIND11_MODULE(_ext, m) {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorU2>(beta);}
         else if (func == "u3") {
           energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelatorU3>(beta);}
-        else if (func == "default") {
-          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelator>(npoint, beta);}
+        else if (func == "generic") {
+          energy_correlator = std::make_shared<fastjet::contrib::EnergyCorrelator>(npoint, beta);} // The generic energy correlator is not normalized; i.e. does not use an momentum fraction when being calculated.
 
         std::vector<double> ECF_vec;
 
@@ -1648,7 +1648,7 @@ PYBIND11_MODULE(_ext, m) {
         Args:
           n_jets: number of exclusive subjets.
           beta: beta parameter for energy correlators.
-          npoint: n-point specification for ECFGs. Also used to determine desired n-point function for all series classes.
+          npoint: n-point specification for ECFs. Also used to determine desired n-point function for all series classes.
           angles: number of angles for generalized energy correlators.
           alpha: alpha parameter for generalized D2.
           func: energy correlator function to use.

--- a/src/_ext.cpp
+++ b/src/_ext.cpp
@@ -1587,12 +1587,6 @@ PYBIND11_MODULE(_ext, m) {
       [](const output_wrapper ow, const int n_jets = 0, const double beta = 1, double npoint = 0, int angles = 0, double alpha = 0, std::string func = "default") {
         auto css = ow.cse;
         int64_t len = css.size();
-        auto jk = 0;
-
-        for (int i = 0; i < len; i++){
-          jk += css[i]->exclusive_jets(n_jets).size();
-        }
-        jk++;
 
         std::transform(func.begin(), func.end(), func.begin(),
           [](unsigned char c){ return std::tolower(c); });

--- a/src/fastjet/__init__.py
+++ b/src/fastjet/__init__.py
@@ -41,7 +41,6 @@ from fastjet._swig import GhostedAreaSpec  # noqa: F401, E402
 from fastjet._swig import GridMedianBackgroundEstimator  # noqa: F401, E402
 from fastjet._swig import IndexedSortHelper  # noqa: F401, E402
 from fastjet._swig import InternalError  # noqa: F401, E402
-from fastjet._swig import JetDefinition  # noqa: F401, E402
 from fastjet._swig import JetDefinition0Param  # noqa: F401, E402
 from fastjet._swig import JetDefinition1Param  # noqa: F401, E402
 from fastjet._swig import JetDefinition2Param  # noqa: F401, E402
@@ -172,6 +171,7 @@ from fastjet._swig import vectorPJ  # noqa: F401, E402
 from fastjet._swig import voronoi_area  # noqa: F401, E402
 from fastjet._swig import zeta2  # noqa: F401, E402
 from fastjet._swig import zeta3  # noqa: F401, E402
+from fastjet._swig import JetDefinition as JetDefinitionNoCast  # noqa: F401, E402
 from fastjet._utils import cos_theta  # noqa: F401, E402
 from fastjet._utils import dot_product  # noqa: F401, E402
 from fastjet._utils import have_same_momentum  # noqa: F401, E402
@@ -186,6 +186,37 @@ from fastjet.version import __version__  # noqa: E402
 
 # TODO: everything should be in this list. Except maybe __version__.
 __all__ = ("__version__",)
+
+
+class JetDefinition(JetDefinitionNoCast):
+    def __init__(
+        self,
+        jet_algorithm_in,
+        R_in,
+        recomb_scheme_in=0,
+        strategy_in=1,
+        nparameters_in=1,
+    ):
+        r"""
+
+        `JetDefinition(JetAlgorithm jet_algorithm_in, double R_in, RecombinationScheme
+            recomb_scheme_in, Strategy strategy_in, int nparameters_in)`
+
+        constructor to fully specify a jet-definition (together with information about
+        how algorithically to run it).
+
+        """
+        if not isinstance(R_in, (float, int)):
+            raise ValueError(
+                f"R_in should be a real number, got {R_in} of type {type(R_in)}"
+            )
+
+        if isinstance(R_in, int):
+            R_in = float(R_in)
+
+        super().__init__(
+            jet_algorithm_in, R_in, recomb_scheme_in, strategy_in, nparameters_in
+        )
 
 
 class ClusterSequence:  # The super class

--- a/src/fastjet/__init__.py
+++ b/src/fastjet/__init__.py
@@ -355,7 +355,7 @@ class ClusterSequence:  # The super class
 
         raise AssertionError()
 
-    def exclusive_jets_energy_correlator(self, njets: int = 10, n_point: int = 2, angle: int = 0, beta: int = 1, alpha = 0, func = "default") -> ak.Array:
+    def exclusive_jets_energy_correlator(self, njets: int = 0, beta: int = 1, npoint: int = 0, angles: int = 0, alpha = 0, func = "default") -> ak.Array:
         """Returns the energy correlator of each exclusive jet.
 
         Args:

--- a/src/fastjet/__init__.py
+++ b/src/fastjet/__init__.py
@@ -355,7 +355,15 @@ class ClusterSequence:  # The super class
 
         raise AssertionError()
 
-    def exclusive_jets_energy_correlator(self, njets: int = 1, beta: int = 1, npoint: int = 0, angles: int = 0, alpha = 0, func = "generalized") -> ak.Array:
+    def exclusive_jets_energy_correlator(
+        self,
+        njets: int = 1,
+        beta: int = 1,
+        npoint: int = 0,
+        angles: int = 0,
+        alpha=0,
+        func="generalized",
+    ) -> ak.Array:
         """Returns the energy correlator of each exclusive jet.
 
         Args:

--- a/src/fastjet/__init__.py
+++ b/src/fastjet/__init__.py
@@ -355,7 +355,7 @@ class ClusterSequence:  # The super class
 
         raise AssertionError()
 
-    def exclusive_jets_energy_correlator(self, njets: int = 0, beta: int = 1, npoint: int = 0, angles: int = 0, alpha = 0, func = "default") -> ak.Array:
+    def exclusive_jets_energy_correlator(self, njets: int = 1, beta: int = 1, npoint: int = 0, angles: int = 0, alpha = 0, func = "generalized") -> ak.Array:
         """Returns the energy correlator of each exclusive jet.
 
         Args:

--- a/src/fastjet/__init__.py
+++ b/src/fastjet/__init__.py
@@ -355,6 +355,19 @@ class ClusterSequence:  # The super class
 
         raise AssertionError()
 
+    def exclusive_jets_energy_correlator(self, njets: int = 10, n_point: int = 2, angle: int = 0, beta: int = 1, alpha = 0, func = "default") -> ak.Array:
+        """Returns the energy correlator of each exclusive jet.
+
+        Args:
+            njets (int): The number of jets it was clustered to.
+            n_point (int): The number of points in the correlator.
+            angle: The number of angles to be used in the correlator (if angle != n_point, ECFG is used).
+            beta: The beta value for the correlator.
+
+        Returns:
+            awkward.highlevel.Array: Returns an Awkward Array of the same type as the input.
+        """
+
     def exclusive_jets_lund_declusterings(self, njets: int = 10) -> ak.Array:
         """Returns the Lund declustering Delta and k_T parameters from exclusive n_jets.
 

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -439,7 +439,7 @@ class _classgeneralevent:
         res = ak.Array(self._replace_multi())
         return res
 
-    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle: int = 0, beta = 1, alpha = 0, func = "default"):
+    def exclusive_jets_energy_correlator(self, njets = 1, n_point = 0, angle: int = 0, beta = 1, alpha = 0, func = "generalized"):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
 

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -439,7 +439,9 @@ class _classgeneralevent:
         res = ak.Array(self._replace_multi())
         return res
 
-    def exclusive_jets_energy_correlator(self, njets = 1, n_point = 0, angle: int = 0, beta = 1, alpha = 0, func = "generalized"):
+    def exclusive_jets_energy_correlator(
+        self, njets=1, n_point=0, angle: int = 0, beta=1, alpha=0, func="generalized"
+    ):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
 

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -439,6 +439,30 @@ class _classgeneralevent:
         res = ak.Array(self._replace_multi())
         return res
 
+    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle: int = 0, beta = 1, alpha = 0, func = "default"):
+        if njets <= 0:
+            raise ValueError("Njets cannot be <= 0")
+
+        self._out = []
+        self._input_flag = 0
+        for i in range(len(self._clusterable_level)):
+            np_results = self._results[i].to_numpy_energy_correlators(
+                njets, n_point, angle, beta, alpha, func
+            )
+            off = np_results[-1]
+            out = ak.Array(  
+                ak.contents.ListOffsetArray(
+                    ak.index.Index64(np_results[0]),
+                    ak.contents.NumpyArray(np_results[1]),
+                    ),
+                behavior=self.data.behavior,
+            )
+            self._out.append(
+                ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
+            )
+        res = ak.Array(self._replace_multi())
+        return res
+
     def exclusive_jets_lund_declusterings(self, njets):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -446,20 +446,8 @@ class _classgeneralevent:
         self._out = []
         self._input_flag = 0
         for i in range(len(self._clusterable_level)):
-            np_results = self._results[i].to_numpy_energy_correlators(
-                njets, n_point, angle, beta, alpha, func
-            )
-            off = np_results[-1]
-            out = ak.Array(  
-                ak.contents.ListOffsetArray(
-                    ak.index.Index64(np_results[0]),
-                    ak.contents.NumpyArray(np_results[1]),
-                    ),
-                behavior=self.data.behavior,
-            )
-            self._out.append(
-                ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
-            )
+            np_results = self._results[i].to_numpy_energy_correlators()
+            self._out.append(ak.Array(ak.contents.NumpyArray(np_results[0])))
         res = ak.Array(self._replace_multi())
         return res
 

--- a/src/fastjet/_multievent.py
+++ b/src/fastjet/_multievent.py
@@ -192,10 +192,10 @@ class _classmultievent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out
 
-    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle = 0, beta = 1, alpha = 0, func = "default"):
+    def exclusive_jets_energy_correlator(self, njets = 0, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "default"):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
-        np_results = self._results.to_numpy_energy_correlators(njets, n_point, angle, beta, alpha, func)        
+        np_results = self._results.to_numpy_energy_correlators(njets, beta, npoint, angles, alpha, func)        
         out = ak.Array(ak.contents.NumpyArray(np_results))
         return out
 

--- a/src/fastjet/_multievent.py
+++ b/src/fastjet/_multievent.py
@@ -192,6 +192,23 @@ class _classmultievent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out
 
+     def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle: int = 0, beta = 1, alpha = 0, func = "default"):
+        if njets <= 0:
+            raise ValueError("Njets cannot be <= 0")
+
+        np_results = self._results.to_numpy_energy_correlators(
+                njets, n_point, angle, beta, alpha, func
+            )
+        off = np_results[-1]
+        out = ak.Array(
+            ak.contents.ListOffsetArray(
+                ak.index.Index64(np_results[0]),
+                ak.contents.NumpyArray(np_results[1]),
+            ),
+        )
+        out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
+        return out
+
     def exclusive_jets_lund_declusterings(self, njets):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")

--- a/src/fastjet/_multievent.py
+++ b/src/fastjet/_multievent.py
@@ -192,7 +192,7 @@ class _classmultievent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out
 
-     def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle: int = 0, beta = 1, alpha = 0, func = "default"):
+    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle: int = 0, beta = 1, alpha = 0, func = "default"):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
 

--- a/src/fastjet/_multievent.py
+++ b/src/fastjet/_multievent.py
@@ -196,7 +196,7 @@ class _classmultievent:
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
         np_results = self._results.to_numpy_energy_correlators(njets, n_point, angle, beta, alpha, func)        
-        out = ak.Array(ak.contents.NumPyArray(np_results))
+        out = ak.Array(ak.contents.NumpyArray(np_results))
         return out
 
     def exclusive_jets_lund_declusterings(self, njets):

--- a/src/fastjet/_multievent.py
+++ b/src/fastjet/_multievent.py
@@ -192,21 +192,11 @@ class _classmultievent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out
 
-    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle: int = 0, beta = 1, alpha = 0, func = "default"):
+    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle = 0, beta = 1, alpha = 0, func = "default"):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
-
-        np_results = self._results.to_numpy_energy_correlators(
-                njets, n_point, angle, beta, alpha, func
-            )
-        off = np_results[-1]
-        out = ak.Array(
-            ak.contents.ListOffsetArray(
-                ak.index.Index64(np_results[0]),
-                ak.contents.NumpyArray(np_results[1]),
-            ),
-        )
-        out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
+        np_results = self._results.to_numpy_energy_correlators(njets, n_point, angle, beta, alpha, func)        
+        out = ak.Array(ak.contents.NumPyArray(np_results))
         return out
 
     def exclusive_jets_lund_declusterings(self, njets):

--- a/src/fastjet/_multievent.py
+++ b/src/fastjet/_multievent.py
@@ -192,10 +192,14 @@ class _classmultievent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out
 
-    def exclusive_jets_energy_correlator(self, njets = 1, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "generalized"):
+    def exclusive_jets_energy_correlator(
+        self, njets=1, beta=1, npoint=0, angles=0, alpha=0, func="generalized"
+    ):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
-        np_results = self._results.to_numpy_energy_correlators(njets, beta, npoint, angles, alpha, func)        
+        np_results = self._results.to_numpy_energy_correlators(
+            njets, beta, npoint, angles, alpha, func
+        )
         out = ak.Array(ak.contents.NumpyArray(np_results))
         return out
 

--- a/src/fastjet/_multievent.py
+++ b/src/fastjet/_multievent.py
@@ -192,7 +192,7 @@ class _classmultievent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out
 
-    def exclusive_jets_energy_correlator(self, njets = 0, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "default"):
+    def exclusive_jets_energy_correlator(self, njets = 1, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "generalized"):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
         np_results = self._results.to_numpy_energy_correlators(njets, beta, npoint, angles, alpha, func)        

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -143,8 +143,12 @@ class AwkwardClusterSequence(ClusterSequence):
     def exclusive_jets_constituents(self, njets=10):
         return self._internalrep.exclusive_jets_constituents(njets)
 
-    def exclusive_jets_energy_correlator(self, njets = 1, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "generalized"):
-        return self._internalrep.exclusive_jets_energy_correlator(njets, beta, npoint, angles, alpha, func)
+    def exclusive_jets_energy_correlator(
+        self, njets=1, beta=1, npoint=0, angles=0, alpha=0, func="generalized"
+    ):
+        return self._internalrep.exclusive_jets_energy_correlator(
+            njets, beta, npoint, angles, alpha, func
+        )
 
     def exclusive_jets_lund_declusterings(self, njets=10):
         return self._internalrep.exclusive_jets_lund_declusterings(njets)
@@ -423,9 +427,20 @@ class DaskAwkwardClusterSequence(ClusterSequence):
 
     def exclusive_jets_constituents(self, njets=10):
         return _dak_dispatch(self, "exclusive_jets_constituents", njets=njets)
-    
-    def exclusive_jets_energy_correlator(self, njets = 1, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "generalized"):
-        return _dak_dispatch(self, "exclusive_jets_energy_correlator", njets=njets, beta=beta, npoint=npoint, angles=angles, alpha=alpha, func=func)
+
+    def exclusive_jets_energy_correlator(
+        self, njets=1, beta=1, npoint=0, angles=0, alpha=0, func="generalized"
+    ):
+        return _dak_dispatch(
+            self,
+            "exclusive_jets_energy_correlator",
+            njets=njets,
+            beta=beta,
+            npoint=npoint,
+            angles=angles,
+            alpha=alpha,
+            func=func,
+        )
 
     def exclusive_jets_lund_declusterings(self, njets=10):
         return _dak_dispatch(self, "exclusive_jets_lund_declusterings", njets=njets)

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -143,8 +143,8 @@ class AwkwardClusterSequence(ClusterSequence):
     def exclusive_jets_constituents(self, njets=10):
         return self._internalrep.exclusive_jets_constituents(njets)
 
-    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle = 2, beta = 1, alpha = 0, func = "default"):
-        return self._internalrep.exclusive_jets_energy_correlator(njets, n_point, angle, beta, alpha, func)
+    def exclusive_jets_energy_correlator(self, njets = 0, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "default"):
+        return self._internalrep.exclusive_jets_energy_correlator(njets, beta, npoint, angles, alpha, func)
 
     def exclusive_jets_lund_declusterings(self, njets=10):
         return self._internalrep.exclusive_jets_lund_declusterings(njets)

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -248,7 +248,7 @@ class _FnDelayedInternalRepCaller:
                 iarray.py.layout._touch_data(recursive=True)
                 iarray.pz.layout._touch_data(recursive=True)
             length_zero_array = ak.Array(
-                array.layout.form.length_zero_array(highevel=False),
+                array.layout.form.length_zero_array(highlevel=False),
                 behavior=array.behavior,
             )
             lz_arrays = tuple(

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -247,16 +247,21 @@ class _FnDelayedInternalRepCaller:
                 iarray.px.layout._touch_data(recursive=True)
                 iarray.py.layout._touch_data(recursive=True)
                 iarray.pz.layout._touch_data(recursive=True)
-            length_zero_array = array.layout.form.length_zero_array(
-                behavior=array.behavior
+            length_zero_array = ak.Array(
+                array.layout.form.length_zero_array(highevel=False),
+                behavior=array.behavior,
             )
             lz_arrays = tuple(
-                iarray.length_zero_array(behavior=iarray.behavior) for iarray in arrays
+                ak.Array(
+                    iarray.length_zero_array(highlevel=False), behavior=iarray.behavior
+                )
+                for iarray in arrays
             )
             seq = AwkwardClusterSequence(length_zero_array, self.jetdef)
             out = getattr(seq, self.name)(*lz_arrays, **self.kwargs)
             return ak.Array(
-                out.layout.to_typetracer(forget_length=True), behavior=out.behavior
+                out.layout.to_typetracer(forget_length=True),
+                behavior=out.behavior,
             )
         seq = AwkwardClusterSequence(array, self.jetdef)
         return getattr(seq, self.name)(*arrays, **self.kwargs)
@@ -284,8 +289,9 @@ class DaskAwkwardClusterSequence(ClusterSequence):
         self._data = data
         self._jagedness = self._check_jaggedness(data._meta)
         self._flag = 1
-        length_zero_data = data._meta.layout.form.length_zero_array(
-            behavior=data.behavior
+        length_zero_data = ak.Array(
+            data._meta.layout.form.length_zero_array(highlevel=False),
+            behavior=data.behavior,
         )
         if (self._check_listoffset(data._meta) and self._jagedness == 2) or (
             self._check_listoffset_index(data._meta)

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -423,6 +423,9 @@ class DaskAwkwardClusterSequence(ClusterSequence):
 
     def exclusive_jets_constituents(self, njets=10):
         return _dak_dispatch(self, "exclusive_jets_constituents", njets=njets)
+    
+    def exclusive_jets_energy_correlator(self, njets = 0, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "default"):
+        return _dak_dispatch(self, "exclusive_jets_energy_correlator", njets=njets, beta=beta, npoint=npoint, angles=angles, alpha=alpha, func=func)
 
     def exclusive_jets_lund_declusterings(self, njets=10):
         return _dak_dispatch(self, "exclusive_jets_lund_declusterings", njets=njets)

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -143,7 +143,7 @@ class AwkwardClusterSequence(ClusterSequence):
     def exclusive_jets_constituents(self, njets=10):
         return self._internalrep.exclusive_jets_constituents(njets)
 
-    def exclusive_jets_energy_correlator(self, njets = 0, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "default"):
+    def exclusive_jets_energy_correlator(self, njets = 1, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "generalized"):
         return self._internalrep.exclusive_jets_energy_correlator(njets, beta, npoint, angles, alpha, func)
 
     def exclusive_jets_lund_declusterings(self, njets=10):

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -143,6 +143,9 @@ class AwkwardClusterSequence(ClusterSequence):
     def exclusive_jets_constituents(self, njets=10):
         return self._internalrep.exclusive_jets_constituents(njets)
 
+    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle = 2, beta = 1, alpha = 0, func = "default"):
+        return self._internalrep.exclusive_jets_energy_correlator(njets, n_point, angle, beta, alpha, func)
+
     def exclusive_jets_lund_declusterings(self, njets=10):
         return self._internalrep.exclusive_jets_lund_declusterings(njets)
 

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -424,7 +424,7 @@ class DaskAwkwardClusterSequence(ClusterSequence):
     def exclusive_jets_constituents(self, njets=10):
         return _dak_dispatch(self, "exclusive_jets_constituents", njets=njets)
     
-    def exclusive_jets_energy_correlator(self, njets = 0, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "default"):
+    def exclusive_jets_energy_correlator(self, njets = 1, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "generalized"):
         return _dak_dispatch(self, "exclusive_jets_energy_correlator", njets=njets, beta=beta, npoint=npoint, angles=angles, alpha=alpha, func=func)
 
     def exclusive_jets_lund_declusterings(self, njets=10):

--- a/src/fastjet/_singleevent.py
+++ b/src/fastjet/_singleevent.py
@@ -180,11 +180,11 @@ class _classsingleevent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out[0]
 
-    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle: int = 0, beta = 1, alpha = 0, func = "default"):
+    def exclusive_jets_energy_correlator(self, njets = 0, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "default"):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
 
-        np_results = self._results.to_numpy_energy_correlators(njets, n_point, angle, beta, alpha, func)
+        np_results = self._results.to_numpy_energy_correlators(njets, beta, npoint, angles, alpha, func)
         off = np_results[-1]
         out = ak.Array(ak.contents.NumpyArray(np_results))
         return out[0]

--- a/src/fastjet/_singleevent.py
+++ b/src/fastjet/_singleevent.py
@@ -180,6 +180,20 @@ class _classsingleevent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out[0]
 
+    def exclusive_jets_energy_correlator(self, njets = 10, n_point = 2, angle: int = 0, beta = 1, alpha = 0, func = "default"):
+        if njets <= 0:
+            raise ValueError("Njets cannot be <= 0")
+
+        np_results = self._results.to_numpy_energy_correlators(njets, n_point, angle, beta, alpha, func)
+        off = np_results[-1]
+        out = ak.Array(
+            ak.contents.ListOffsetArray(
+                ak.index.Index64(np_results[0]), ak.contents.NumpyArray(np_results[1])
+            )
+        )
+        out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
+        return out[0]
+
     def exclusive_jets_lund_declusterings(self, njets):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")

--- a/src/fastjet/_singleevent.py
+++ b/src/fastjet/_singleevent.py
@@ -186,12 +186,7 @@ class _classsingleevent:
 
         np_results = self._results.to_numpy_energy_correlators(njets, n_point, angle, beta, alpha, func)
         off = np_results[-1]
-        out = ak.Array(
-            ak.contents.ListOffsetArray(
-                ak.index.Index64(np_results[0]), ak.contents.NumpyArray(np_results[1])
-            )
-        )
-        out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
+        out = ak.Array(ak.contents.NumPyArray(np_results))
         return out[0]
 
     def exclusive_jets_lund_declusterings(self, njets):

--- a/src/fastjet/_singleevent.py
+++ b/src/fastjet/_singleevent.py
@@ -189,7 +189,6 @@ class _classsingleevent:
         np_results = self._results.to_numpy_energy_correlators(
             njets, beta, npoint, angles, alpha, func
         )
-        off = np_results[-1]
         out = ak.Array(ak.contents.NumpyArray(np_results))
         return out[0]
 

--- a/src/fastjet/_singleevent.py
+++ b/src/fastjet/_singleevent.py
@@ -180,11 +180,15 @@ class _classsingleevent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out[0]
 
-    def exclusive_jets_energy_correlator(self, njets = 1, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "generalized"):
+    def exclusive_jets_energy_correlator(
+        self, njets=1, beta=1, npoint=0, angles=0, alpha=0, func="generalized"
+    ):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
 
-        np_results = self._results.to_numpy_energy_correlators(njets, beta, npoint, angles, alpha, func)
+        np_results = self._results.to_numpy_energy_correlators(
+            njets, beta, npoint, angles, alpha, func
+        )
         off = np_results[-1]
         out = ak.Array(ak.contents.NumpyArray(np_results))
         return out[0]

--- a/src/fastjet/_singleevent.py
+++ b/src/fastjet/_singleevent.py
@@ -186,7 +186,7 @@ class _classsingleevent:
 
         np_results = self._results.to_numpy_energy_correlators(njets, n_point, angle, beta, alpha, func)
         off = np_results[-1]
-        out = ak.Array(ak.contents.NumPyArray(np_results))
+        out = ak.Array(ak.contents.NumpyArray(np_results))
         return out[0]
 
     def exclusive_jets_lund_declusterings(self, njets):

--- a/src/fastjet/_singleevent.py
+++ b/src/fastjet/_singleevent.py
@@ -180,7 +180,7 @@ class _classsingleevent:
         out = ak.Array(ak.contents.ListOffsetArray(ak.index.Index64(off), out.layout))
         return out[0]
 
-    def exclusive_jets_energy_correlator(self, njets = 0, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "default"):
+    def exclusive_jets_energy_correlator(self, njets = 1, beta = 1, npoint = 0, angles = 0, alpha = 0, func = "generalized"):
         if njets <= 0:
             raise ValueError("Njets cannot be <= 0")
 

--- a/tests/test_002-exclusive_jets.py
+++ b/tests/test_002-exclusive_jets.py
@@ -188,9 +188,9 @@ def test_exclusive_energy_correlator():
     jetdef = fastjet.JetDefinition(fastjet.cambridge_algorithm, 0.8)
     cluster = fastjet._pyjet.AwkwardClusterSequence(array, jetdef)
 
-    ec1 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=1)
-    ec2 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=2)
-    ecg2 = cluster.exclusive_jets_energy_correlator(func='generalized', npoint=2, angles=1)
+    ec1 = cluster.exclusive_jets_energy_correlator(func="generic", npoint=1)
+    ec2 = cluster.exclusive_jets_energy_correlator(func="generic", npoint=2)
+    ecg2 = cluster.exclusive_jets_energy_correlator(func="generalized", npoint=2, angles=1)
 
     is_close = ak.ravel(ak.isclose(ak.Array([ec2/ec1/ec1]), ak.Array([ecg2]), rtol=1e-12, atol=0))
 
@@ -220,9 +220,9 @@ def test_exclusive_energy_correlator_multi():
     jetdef = fastjet.JetDefinition(fastjet.cambridge_algorithm, 0.8)
     cluster = fastjet._pyjet.AwkwardClusterSequence(array, jetdef)
 
-    ec1 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=1)
-    ec2 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=2)
-    ecg2 = cluster.exclusive_jets_energy_correlator(func='generalized', npoint=2, angles=1)
+    ec1 = cluster.exclusive_jets_energy_correlator(func="generic", npoint=1)
+    ec2 = cluster.exclusive_jets_energy_correlator(func="generic", npoint=2)
+    ecg2 = cluster.exclusive_jets_energy_correlator(func="generalized", npoint=2, angles=1)
 
     is_close = ak.ravel(ak.isclose((ec2/ec1/ec1), ecg2, rtol=1e-12, atol=0))
 

--- a/tests/test_002-exclusive_jets.py
+++ b/tests/test_002-exclusive_jets.py
@@ -185,14 +185,16 @@ def test_exclusive_energy_correlator():
         with_name="Momentum4D",
     )
 
-    jetdef = fastjet.JetDefinition(fastjet.antikt_algorithm, 0.8)
+    jetdef = fastjet.JetDefinition(fastjet.cambridge_algorithm, 0.8)
     cluster = fastjet._pyjet.AwkwardClusterSequence(array, jetdef)
 
     ec1 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=1)
     ec2 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=2)
     ecg2 = cluster.exclusive_jets_energy_correlator(func='generalized', npoint=2, angles=1)
 
-    assert ((ec2/ec1/ec1) == ecg2)
+    is_close = ak.ravel(ak.isclose(ak.Array([ec2/ec1/ec1]), ak.Array([ecg2]), rtol=1e-12, atol=0))
+
+    assert ak.all(is_close)
 
 def test_exclusive_energy_correlator_multi():
     array = ak.Array(
@@ -222,7 +224,9 @@ def test_exclusive_energy_correlator_multi():
     ec2 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=2)
     ecg2 = cluster.exclusive_jets_energy_correlator(func='generalized', npoint=2, angles=1)
 
-    assert ak.all((ec2/ec1/ec1) == ecg2)
+    is_close = ak.ravel(ak.isclose((ec2/ec1/ec1), ecg2, rtol=1e-12, atol=0))
+
+    assert ak.all(is_close)
 
 def test_exclusive_constituents_multi():
     array = ak.Array(

--- a/tests/test_002-exclusive_jets.py
+++ b/tests/test_002-exclusive_jets.py
@@ -173,6 +173,7 @@ def test_exclusive_lund_declustering_multi():
 
     assert ak.all(is_close)
 
+
 def test_exclusive_energy_correlator():
     array = ak.Array(
         [
@@ -190,11 +191,16 @@ def test_exclusive_energy_correlator():
 
     ec1 = cluster.exclusive_jets_energy_correlator(func="generic", npoint=1)
     ec2 = cluster.exclusive_jets_energy_correlator(func="generic", npoint=2)
-    ecg2 = cluster.exclusive_jets_energy_correlator(func="generalized", npoint=2, angles=1)
+    ecg2 = cluster.exclusive_jets_energy_correlator(
+        func="generalized", npoint=2, angles=1
+    )
 
-    is_close = ak.ravel(ak.isclose(ak.Array([ec2/ec1/ec1]), ak.Array([ecg2]), rtol=1e-12, atol=0))
+    is_close = ak.ravel(
+        ak.isclose(ak.Array([ec2 / ec1 / ec1]), ak.Array([ecg2]), rtol=1e-12, atol=0)
+    )
 
     assert ak.all(is_close)
+
 
 def test_exclusive_energy_correlator_multi():
     array = ak.Array(
@@ -222,11 +228,14 @@ def test_exclusive_energy_correlator_multi():
 
     ec1 = cluster.exclusive_jets_energy_correlator(func="generic", npoint=1)
     ec2 = cluster.exclusive_jets_energy_correlator(func="generic", npoint=2)
-    ecg2 = cluster.exclusive_jets_energy_correlator(func="generalized", npoint=2, angles=1)
+    ecg2 = cluster.exclusive_jets_energy_correlator(
+        func="generalized", npoint=2, angles=1
+    )
 
-    is_close = ak.ravel(ak.isclose((ec2/ec1/ec1), ecg2, rtol=1e-12, atol=0))
+    is_close = ak.ravel(ak.isclose((ec2 / ec1 / ec1), ecg2, rtol=1e-12, atol=0))
 
     assert ak.all(is_close)
+
 
 def test_exclusive_constituents_multi():
     array = ak.Array(

--- a/tests/test_002-exclusive_jets.py
+++ b/tests/test_002-exclusive_jets.py
@@ -173,6 +173,56 @@ def test_exclusive_lund_declustering_multi():
 
     assert ak.all(is_close)
 
+def test_exclusive_energy_correlator():
+    array = ak.Array(
+        [
+            {"px": 1.2, "py": 3.2, "pz": 5.4, "E": 2.5, "ex": 0.78},
+            {"px": 1.25, "py": 3.15, "pz": 5.4, "E": 2.4, "ex": 0.78},
+            {"px": 1.4, "py": 3.15, "pz": 5.4, "E": 2.0, "ex": 0.78},
+            {"px": 32.2, "py": 64.21, "pz": 543.34, "E": 24.12, "ex": 0.35},
+            {"px": 32.45, "py": 63.21, "pz": 543.14, "E": 24.56, "ex": 0.0},
+        ],
+        with_name="Momentum4D",
+    )
+
+    jetdef = fastjet.JetDefinition(fastjet.antikt_algorithm, 0.8)
+    cluster = fastjet._pyjet.AwkwardClusterSequence(array, jetdef)
+
+    ec1 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=1)
+    ec2 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=2)
+    ecg2 = cluster.exclusive_jets_energy_correlator(func='generalized', npoint=2, angles=1)
+
+    assert ((ec2/ec1/ec1) == ecg2)
+
+def test_exclusive_energy_correlator_multi():
+    array = ak.Array(
+        [
+            [
+                {"px": 1.2, "py": 3.2, "pz": 5.4, "E": 2.5, "ex": 0.78},
+                {"px": 1.25, "py": 3.15, "pz": 5.4, "E": 2.4, "ex": 0.78},
+                {"px": 1.4, "py": 3.15, "pz": 5.4, "E": 2.0, "ex": 0.78},
+                {"px": 32.2, "py": 64.21, "pz": 543.34, "E": 24.12, "ex": 0.35},
+                {"px": 32.45, "py": 63.21, "pz": 543.14, "E": 24.56, "ex": 0.0},
+            ],
+            [
+                {"px": 1.2, "py": 3.2, "pz": 5.4, "E": 2.5, "ex": 0.78},
+                {"px": 1.25, "py": 3.15, "pz": 5.4, "E": 2.4, "ex": 0.78},
+                {"px": 1.4, "py": 3.15, "pz": 5.4, "E": 2.0, "ex": 0.78},
+                {"px": 32.2, "py": 64.21, "pz": 543.34, "E": 24.12, "ex": 0.35},
+                {"px": 32.45, "py": 63.21, "pz": 543.14, "E": 24.56, "ex": 0.0},
+            ],
+        ],
+        with_name="Momentum4D",
+    )
+
+    jetdef = fastjet.JetDefinition(fastjet.cambridge_algorithm, 0.8)
+    cluster = fastjet._pyjet.AwkwardClusterSequence(array, jetdef)
+
+    ec1 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=1)
+    ec2 = cluster.exclusive_jets_energy_correlator(func='generic', npoint=2)
+    ecg2 = cluster.exclusive_jets_energy_correlator(func='generalized', npoint=2, angles=1)
+
+    assert ak.all((ec2/ec1/ec1) == ecg2)
 
 def test_exclusive_constituents_multi():
     array = ak.Array(


### PR DESCRIPTION
Hello,

I have implemented `exclusive_jets_energy_correlator` to calculate the ECFs and ECFGs of a fatjet, as well as the included combinations (i.e. N2, D2, and so on). 

An important note: I have made the generalized ECF (ECFG) the default case, because the generic ECF does not include baked in normalization, which I suspect most users would expect out of the gate. That said, the combinations will probably be used more often than the the basic ECF, especially NSeries and D2. 