### PR TITLE
ci: Use file from cloned repo instead of https access

### DIFF
--- a/tests/test_008-dask.py
+++ b/tests/test_008-dask.py
@@ -92,12 +92,13 @@ def test_single():
 
 
 def test_inclusive_from_file():
+    import os
     import uproot
     from dask_awkward.lib.testutils import assert_eq
 
     vector = pytest.importorskip("vector")
 
-    testfile = "https://github.com/scikit-hep/fastjet/blob/main/tests/samples/pfnano_skim.root?raw=true"
+    testfile = os.getcwd() + "/tests/samples/pfnano_skim.root"
 
     devents = uproot.dask({testfile: "Events"})
 

--- a/tests/test_008-dask.py
+++ b/tests/test_008-dask.py
@@ -93,6 +93,7 @@ def test_single():
 
 def test_inclusive_from_file():
     import os
+
     import uproot
     from dask_awkward.lib.testutils import assert_eq
 

--- a/tests/test_008-dask.py
+++ b/tests/test_008-dask.py
@@ -92,14 +92,15 @@ def test_single():
 
 
 def test_inclusive_from_file():
-    import os
+    from pathlib import Path
 
     import uproot
     from dask_awkward.lib.testutils import assert_eq
 
     vector = pytest.importorskip("vector")
 
-    testfile = os.getcwd() + "/tests/samples/pfnano_skim.root"
+    data_dir = Path(__file__).parent / "samples"
+    testfile = data_dir / "pfnano_skim.root"
 
     devents = uproot.dask({testfile: "Events"})
 


### PR DESCRIPTION
Cirrus CI is having issues with accessing the sample file over `https` for the python 3.11 jobs. 
I switched to use the local file from the cloned repository.