### PR TITLE
fix: try using flattened array instead of ak.Array(<components>)

### DIFF
--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -214,7 +214,7 @@ class _classgeneralevent:
         px = ak.to_numpy(array.px.layout.content)
         py = ak.to_numpy(array.py.layout.content)
         pz = ak.to_numpy(array.pz.layout.content)
-        E = ak.to_numpy(array.E.layout.content)        
+        E = ak.to_numpy(array.E.layout.content)
         off = np.asarray(array.layout.stops)
         off = np.insert(off, 0, 0)
         return px, py, pz, E, off

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -211,10 +211,11 @@ class _classgeneralevent:
             return False
 
     def extract_cons(self, array):
-        px = ak.to_numpy(array.px.layout.content)
-        py = ak.to_numpy(array.py.layout.content)
-        pz = ak.to_numpy(array.pz.layout.content)
-        E = ak.to_numpy(array.E.layout.content)
+        # just to run the tests
+        px = np.asarray(ak.Array(array.layout.content, behavior=array.behavior).px)
+        py = np.asarray(ak.Array(array.layout.content, behavior=array.behavior).py)
+        pz = np.asarray(ak.Array(array.layout.content, behavior=array.behavior).pz)
+        E = np.asarray(ak.Array(array.layout.content, behavior=array.behavior).E)
         off = np.asarray(array.layout.stops)
         off = np.insert(off, 0, 0)
         return px, py, pz, E, off

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -211,10 +211,11 @@ class _classgeneralevent:
             return False
 
     def extract_cons(self, array):
-        px = np.asarray(ak.Array(array.layout.content, behavior=array.behavior).px)
-        py = np.asarray(ak.Array(array.layout.content, behavior=array.behavior).py)
-        pz = np.asarray(ak.Array(array.layout.content, behavior=array.behavior).pz)
-        E = np.asarray(ak.Array(array.layout.content, behavior=array.behavior).E)
+        packed_flattened = ak.to_packed(ak.flatten(array))
+        px = packed_flattened.px
+        py = packed_flattened.py
+        pz = packed_flattened.pz
+        E = packed_flattened.E
         off = np.asarray(array.layout.stops)
         off = np.insert(off, 0, 0)
         return px, py, pz, E, off

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -211,11 +211,10 @@ class _classgeneralevent:
             return False
 
     def extract_cons(self, array):
-        packed_flattened = ak.flatten(array)
-        px = packed_flattened.px.to_numpy()
-        py = packed_flattened.py.to_numpy()
-        pz = packed_flattened.pz.to_numpy()
-        E = packed_flattened.E.to_numpy()
+        px = ak.to_numpy(array.px.layout.content)
+        py = ak.to_numpy(array.py.layout.content)
+        pz = ak.to_numpy(array.pz.layout.content)
+        E = ak.to_numpy(array.E.layout.content)        
         off = np.asarray(array.layout.stops)
         off = np.insert(off, 0, 0)
         return px, py, pz, E, off

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -211,7 +211,7 @@ class _classgeneralevent:
             return False
 
     def extract_cons(self, array):
-        packed_flattened = ak.to_packed(ak.flatten(array))
+        packed_flattened = ak.flatten(array)
         px = packed_flattened.px
         py = packed_flattened.py
         pz = packed_flattened.pz

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -212,10 +212,10 @@ class _classgeneralevent:
 
     def extract_cons(self, array):
         packed_flattened = ak.flatten(array)
-        px = packed_flattened.px
-        py = packed_flattened.py
-        pz = packed_flattened.pz
-        E = packed_flattened.E
+        px = packed_flattened.px.to_numpy()
+        py = packed_flattened.py.to_numpy()
+        pz = packed_flattened.pz.to_numpy()
+        E = packed_flattened.E.to_numpy()
         off = np.asarray(array.layout.stops)
         off = np.insert(off, 0, 0)
         return px, py, pz, E, off


### PR DESCRIPTION
This appears to be dropping `with_name` information in some cases that causes code using `ak.mask` to fail.

@btovar