### PR TITLE
fix: Update RPATH and fully guard ORIGIN parameter expansion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 f"--with-cgaldir={cgal_dir}",
                 "--enable-swig",
                 "--enable-pyext",
-                "LDFLAGS=-Wl,-rpath,$$ORIGIN/_fastjet_core/lib:$$ORIGIN",
+                "LDFLAGS=-Wl,-rpath,$ORIGIN/_fastjet_core/lib:$ORIGIN",
             ]
 
             try:

--- a/setup.py
+++ b/setup.py
@@ -66,10 +66,16 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 cwd=FASTJET,
             )
 
+            # RPATH is set for shared libraries in the following locations:
+            # * fastjet/
+            # * fastjet/_fastjet_core/lib/
+            # * fastjet/_fastjet_core/lib/python*/site-packages/
+            _rpath = "'$$ORIGIN/_fastjet_core/lib:$$ORIGIN:$$ORIGIN/../..'"
             env = os.environ.copy()
             env["PYTHON"] = sys.executable
             env["PYTHON_INCLUDE"] = f'-I{sysconfig.get_path("include")}'
             env["CXXFLAGS"] = "-O3 -Bstatic -lgmp -Bdynamic -std=c++17"
+            env["LDFLAGS"] = env.get("LDFLAGS", "") + f" -Wl,-rpath,{_rpath}"
             env["ORIGIN"] = "$ORIGIN"  # if evaluated, it will still be '$ORIGIN'
 
             args = [
@@ -82,7 +88,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 f"--with-cgaldir={cgal_dir}",
                 "--enable-swig",
                 "--enable-pyext",
-                "LDFLAGS=-Wl,-rpath,$ORIGIN/_fastjet_core/lib:$ORIGIN",
+                f'LDFLAGS={env["LDFLAGS"]}',
             ]
 
             try:
@@ -98,6 +104,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
 
             env = os.environ.copy()
             env["CXX"] = env.get("CXX", "g++")
+            env["LDFLAGS"] = env.get("LDFLAGS", "") + f" -Wl,-rpath,{_rpath}"
             env["ORIGIN"] = "$ORIGIN"  # if evaluated, it will still be '$ORIGIN'
             subprocess.run(["make", "-j"], cwd=FASTJET, env=env, check=True)
             subprocess.run(["make", "install"], cwd=FASTJET, env=env, check=True)
@@ -108,6 +115,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                     f"--fastjet-config={FASTJET}/fastjet-config",
                     f'CXX={env["CXX"]}',
                     "CXXFLAGS=-O3 -Bstatic -Bdynamic -std=c++17",
+                    f'LDFLAGS={env["LDFLAGS"]}',
                 ],
                 cwd=FASTJET_CONTRIB,
                 env=env,


### PR DESCRIPTION
Requires PR #276 to go in first. (Splitting these to keep the commits atomic)

Use of `$$` for the parameter expansion of `ORIGIN` results in a failure to properly resolve `$ORIGIN` and for `LDFLAGS` to be set improperly. Use `$ORIGIN` instead.

c.f. https://github.com/lgray/staged-recipes/pull/3 for this patch being required for a build to succeed for https://github.com/conda-forge/staged-recipes/pull/21052.

The use of `$$` was added by @jpivarski in PR https://github.com/scikit-hep/fastjet/pull/65, so maybe he can elaborate on the need there and if this PR is missing something. A quick scan of the PR makes it seem like

>  Different parts of the configure/make procedure evaluate it at different levels, so just protecting the `$` is not enough: I had to define an environment variable so that `$ORIGIN` would resolve to "`$ORIGIN`".

would be the most relevant bit, but that seems to not matter here.