### PR TITLE
fix: Remove patch_fastjet_i.txt from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ graft fastjet-core
 graft fastjet-contrib
 graft pybind11
 global-exclude .git .gitmodules
-include LICENSE README.md pyproject.toml setup.py setup.cfg patch_fastjet_i.txt patch_clustersequence.txt
+include LICENSE README.md pyproject.toml setup.py setup.cfg patch_clustersequence.txt
 exclude .cirrus.yml


### PR DESCRIPTION
Amends PR #206 

`patch_fastjet_i.txt` was removed in PR #206 and so should be removed from the MANIFEST to avoid warnings.