### PR TITLE
ci: Add Python 3.12 to testing matrix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,6 @@ task:
         memory: 6G
         matrix:
           - image: python:3.8
-          - image: python:3.11
           - image: python:3.12
 
       install_build_dependencies_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,7 @@ task:
         matrix:
           - image: python:3.8
           - image: python:3.11
+          - image: python:3.12
 
       install_build_dependencies_script: |
         apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11", "3.12"]
+        python-version: ["3.8", "3.12"]
         runs-on: [ubuntu-latest, macos-latest]
         arch: [auto64]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.11", "3.12"]
         runs-on: [ubuntu-latest, macos-latest]
         arch: [auto64]
     steps:
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: [311]
+        python: [312]
         arch: [auto64]
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [38, 39, 310, 311]
+        python: [38, 39, 310, 311, 312]
         os: [ubuntu-latest, macos-latest]
         arch: [auto64]
         include:
@@ -43,6 +43,9 @@ jobs:
             os: ubuntu-latest
             arch: aarch64
           - python: 311
+            os: ubuntu-latest
+            arch: aarch64
+          - python: 312
             os: ubuntu-latest
             arch: aarch64
 


### PR DESCRIPTION
* Update the CI to also test Python 3.12 and use it as a default in situations where only one version is tested.