### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.12"]
-        runs-on: [ubuntu-latest, macos-latest]
+        runs-on: [ubuntu-latest, macos-13]
         arch: [auto64]
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         python: [312]
         arch: [auto64]
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [38, 39, 310, 311, 312]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         arch: [auto64]
         include:
           - python: 38


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos