### PR TITLE
build: Remove transient directories after install to allow for rebuild

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,13 @@ FASTJET_CONTRIB = DIR / "fastjet-contrib"
 PYTHON = DIR / "src/fastjet"
 OUTPUT = PYTHON / "_fastjet_core"
 
+
+# Clean up transient directories to allow for rebuilds during development
+if (DIR / "build").exists():
+    shutil.rmtree(DIR / "build")
+if OUTPUT.exists():
+    shutil.rmtree(OUTPUT)
+
 LIBS = [
     "fastjet",
     "fastjettools",


### PR DESCRIPTION
* Addresses part of Issue #279 
* Addresses part of Discussion #302

While doing multiple rebuilds it is advisable to also clean up the state of the Git submodules with `git clean -f`, removing the `OUTPUT` directory at `src/fastjet/_fastjet_core/` and the top level build directory is sufficient to do local development rebuilds &mdash; i.e., the command `python -m pip install --upgrade .` can be run twice in a row without error.