### PR TITLE
build: Use build-system pybind11 over Git submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
           echo $PATH
           python -m pip install '.[test]' -v
 
+      - name: List installed Python packages
+        run: python -m pip list
+
       - name: Test package
         run: python -m pytest -vv -rs -Wd
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "fastjet"]
 	path = extern/fastjet-core
 	url = https://gitlab.com/fastjet/fastjet.git
-[submodule "pybind11"]
-	path = pybind11
-	url = https://github.com/pybind/pybind11.git
 [submodule "fastjet-contrib"]
 	path = extern/fastjet-contrib
 	url = https://github.com/cms-externals/fastjet-contrib.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 graft src
 graft tests
 graft extern
-graft pybind11
 global-exclude .git .gitmodules
 include LICENSE README.md pyproject.toml setup.py setup.cfg patch_clustersequence.txt
 exclude .cirrus.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "setuptools_scm[toml]>=3.4",
-    "pybind11>=2.6.1",
+    "pybind11>=2.12.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Resolves #309 

* Update lower bound on build-system pybind11 to v2.12.0 to add support for compiling for NumPy 2.0.
   - c.f. https://github.com/pybind/pybind11/releases/tag/v2.12.0
* Remove pybind11 submodule to use build-system instead.
* Add an easy to parse log of the environment used for each test, which is useful for debugging differences between CI jobs seperated in time.


For reference, the `pybind11` Git submodule was added in https://github.com/scikit-hep/fastjet/commit/0f9f8fff63761aa63a50471f22880b579b1e6ff2 by @jpivarski, though as this wasn't part of a PR I'm not sure why the Git submodule approach was used over [the other `pybind11` install methods](https://pybind11.readthedocs.io/en/stable/installing.html).