### PR TITLE
build: Remove manual CGAL install

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,7 @@ task:
           gcc \
           g++ \
           libboost-dev \
+          libcgal-dev \
           libmpfr-dev \
           libgmp-dev \
           swig \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,14 @@ jobs:
       - name: Install compiler tools on macOS
         if: runner.os == 'macOS'
         run: |
-          brew install make automake swig gmp mpfr boost
+          brew install make automake swig gmp mpfr boost cgal
           export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
 
       - name: Install extra deps on Linux
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libboost-dev libmpfr-dev swig autoconf libtool
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-dev libcgal-dev libmpfr-dev swig autoconf libtool
 
       - name: Install package
         run: |
@@ -89,7 +91,7 @@ jobs:
       - name: Install compiler tools on macOS
         if: runner.os == 'macOS'
         run: |
-          brew install make automake swig mpfr boost
+          brew install make automake swig mpfr boost cgal
           export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
 
       - name: Clone gmp

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install compiler tools on macOS
         if: runner.os == 'macOS'
         run: |
-          brew install make automake swig mpfr boost
+          brew install make automake swig mpfr boost cgal
           export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
 
       - name: Clone gmp
@@ -112,7 +112,9 @@ jobs:
 
       - name: Install extra deps on Linux
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libboost-dev swig autoconf libtool
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-dev libcgal-dev swig autoconf libtool
 
       - name: test sdist
         run: python -m pip install dist/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,3 @@ cython_debug/
 *.exe
 *.out
 *.app
-
-# Build dependencies
-CGAL*

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To install the build-time dependencies run the following installation commands f
 ### Debian/Ubuntu
 
 ``` bash
-sudo apt-get update && sudo apt-get install -y libboost-dev libmpfr-dev libgmp-dev swig autoconf libtool
+sudo apt-get update && sudo apt-get install -y libboost-dev libcgal-dev libmpfr-dev libgmp-dev swig autoconf libtool
 ```
 
 ## Build and install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ before-all = [
     "curl -L https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.bz2 -o boost_1_84_0.tar.bz2",
     "tar --bzip2 -xf boost_1_84_0.tar.bz2",
     "mv boost_1_84_0/boost /usr/include/boost",
+    "curl -LO https://github.com/CGAL/cgal/releases/download/v5.6.1/CGAL-5.6.1-library.zip",
+    "unzip -q CGAL-5.6.1-library.zip",
+    "mv CGAL-5.6.1/include/CGAL /usr/include/",
 ]
 # Skip musllinux builds for the moment
 skip = "*-musllinux_*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ manylinux-i686-image = "manylinux2014"
 before-all = [
     "yum update -y",
     "yum install -y mpfr-devel",
-    "curl -L https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.bz2 -o boost_1_84_0.tar.bz2",
+    "curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.bz2",
     "tar --bzip2 -xf boost_1_84_0.tar.bz2",
     "mv boost_1_84_0/boost /usr/include/boost",
     "curl -LO https://github.com/CGAL/cgal/releases/download/v5.6.1/CGAL-5.6.1-library.zip",

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,9 @@ import shutil
 import subprocess
 import sys
 import sysconfig
-import urllib.request
-import zipfile
 
 import setuptools.command.build_ext
 import setuptools.command.install
-
-CGAL_ZIP = "https://github.com/CGAL/cgal/releases/download/v5.6/CGAL-5.6-library.zip"
 
 DIR = pathlib.Path(__file__).parent.resolve()
 FASTJET = DIR / "extern" / "fastjet-core"
@@ -56,16 +52,6 @@ def get_version() -> str:
 class FastJetBuild(setuptools.command.build_ext.build_ext):
     def build_extensions(self):
         if not OUTPUT.exists():
-            zip_filename = DIR / pathlib.Path(CGAL_ZIP).parts[-1]
-
-            with urllib.request.urlopen(CGAL_ZIP) as http_obj:
-                with open(zip_filename, "wb") as file_obj:
-                    shutil.copyfileobj(http_obj, file_obj)
-
-            with zipfile.ZipFile(zip_filename) as zip_obj:
-                cgal_dir = DIR / zip_obj.namelist()[0]
-                zip_obj.extractall(DIR)
-
             # Patch for segfault of LimitedWarning
             # For more info see https://github.com/scikit-hep/fastjet/pull/131
             subprocess.run(
@@ -92,7 +78,6 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 "--enable-allcxxplugins",
                 "--enable-cgal-header-only",
                 "--enable-cgal",
-                f"--with-cgaldir={cgal_dir}",
                 "--enable-swig",
                 "--enable-pyext",
                 f'LDFLAGS={env["LDFLAGS"]}',

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 "--disable-auto-ptr",
                 "--enable-allcxxplugins",
                 "--enable-cgal-header-only",
-                "--enable-cgal",
                 "--enable-swig",
                 "--enable-pyext",
                 f'LDFLAGS={env["LDFLAGS"]}',

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 "--disable-auto-ptr",
                 "--enable-allcxxplugins",
                 "--enable-cgal-header-only",
+                "--enable-cgal",
                 "--enable-swig",
                 "--enable-pyext",
                 f'LDFLAGS={env["LDFLAGS"]}',


### PR DESCRIPTION
Addresses (and maybe resolves, will need to check) Issue https://github.com/scikit-hep/fastjet/issues/193.

* build: Remove manual CGAL install
   - Remove the manual download of CGAL from setup.py.
   - Remove `--with-cgaldir` `autogen.sh` flag as CGAL should be installed in a location by the package managers or user that it is findable.

* build: Add manual CGAL install for Linux cibuildwheel 
   - The cibuildwheel Linux container is CentOS 7 based, but CGAL is not packaged for CentOS with `yum` &mdash; only for `apt-get`, Homebrew, and `conda-forge`. For Linux cibuildwheel builds this then requires that the CGAL headers (CGAL is header only) need to be manually downloaded from GitHub and then copied into `/usr/include/`.

* docs: Add `libcgal-dev` install to README 
   - Add `libcgal-dev` to the required packages to install for Linux based development.

* ci: Add cgal install to CI 
   - Use package managers to install `libcgal-dev` (Linux) and `cgal` (macOS) in CI jobs.