### PR TITLE
fix(DO NOT MERGE): Remove '--enable-cgal' option incompatible with header-only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ class FastJetBuild(setuptools.command.build_ext.build_ext):
                 "--disable-auto-ptr",
                 "--enable-allcxxplugins",
                 "--enable-cgal-header-only",
-                "--enable-cgal",
                 f"--with-cgaldir={cgal_dir}",
                 "--enable-swig",
                 "--enable-pyext",


### PR DESCRIPTION
* Resolves https://github.com/scikit-hep/fastjet/issues/193
* Will also fix the problem that PR #301 is stuck on
* Reverts most of PR #70

---

* After FastJet's `autogen.sh` has been run and the `configure` script generated, `./configure --help` shows

```
  --enable-cgal           enables link with the CGAL library default=no
  --enable-cgal-header-only   enable build with header-only install of CGAL, e.g. as for CGALv5; in that case do not use --enable-cgal default=no
```

   - c.f. https://gitlab.com/fastjet/fastjet/-/tree/67796a1d43981d25a0f6d197fdfb71571028caf0

* As CGAL is a header only library there is no need to link against it or configure it and so the `--enable-cgal-header-only` is all that is required.
   - c.f. https://doc.cgal.org/5.6.1/Manual/usage.html#section_headeronly
* Removal of the option conflict seems to resolve multiple issues linking errors with CGAL.