### PR TITLE
Fix typo in definition of constituents (pt instead of p)

### DIFF
--- a/src/fastjet/__init__.py
+++ b/src/fastjet/__init__.py
@@ -347,7 +347,7 @@ class ClusterSequence:  # The super class
 
         raise AssertionError()
 
-    def constituents(self, min_p: float = 0) -> ak.Array:
+    def constituents(self, min_pt: float = 0) -> ak.Array:
         """Returns the particles that make up each Jet.
 
         Args:


### PR DESCRIPTION
Very trivial change. The input of `constituents()` is supposed to be `min_pt` not `min_p`. When naming the input argument, it causes issues with static code analyzers and type checkers. 