### PR TITLE
fix: propagate metadata (behavior & attrs) in `_generalevent.py`

### DIFF
--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -19,7 +19,9 @@ class _classgeneralevent:
         self.multi_layered_listoffset(self.data, ())
         for i in range(len(self._clusterable_level)):
             self._clusterable_level[i] = ak.Array(
-                self._clusterable_level[i].layout.to_ListOffsetArray64(True)
+                self._clusterable_level[i].layout.to_ListOffsetArray64(True),
+                behavior=data.behavior,
+                attrs=data.attrs,
             )
             px, py, pz, E, offsets = self.extract_cons(self._clusterable_level[i])
             px = self.correct_byteorder(px)


### PR DESCRIPTION
(Hopefully) fixes https://github.com/scikit-hep/fastjet/issues/298

Can you give it a try (@jennetd & @lgray) ?

(Hm... It might be more correct to propagate behavior and attrs in each `self.multi_layered_listoffset` call, but I think it makes no difference here and thus I went with the smaller code change)