### PR TITLE
build: add more build options; obviates fastjet-feedstock patch for passthru submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,14 @@ list(GET VERSION_SPLIT 1 SPLIT_VERSION_MINOR)
 
 project(fastjet VERSION ${SPLIT_VERSION_MAJOR}.${SPLIT_VERSION_MINOR} LANGUAGES CXX)
 
-option(SKHEPFJ_USE_INSTALLED_FASTJET          "Use an existing installed version of fastjet"         OFF)
-option(SKHEPFJ_USE_INSTALLED_FASTJET_CONTRIB  "Use an existing installed version of fastjet-contrib" OFF)
-option(SKHEPFJ_PATCH_FJCORE                   "Patch fastjet-contrib with CMAKE_INSTALL_LIBDIR use"  ON)
-option(SKHEPFJ_PATCH_FJCONTRIB                "Patch fastjet-contrib with cmake build"               ON)
+option(SKHEPFJ_USE_INSTALLED_FASTJET         "Use an existing installed version of fastjet"                         OFF)
+option(SKHEPFJ_USE_INSTALLED_FASTJET_CONTRIB "Use an existing installed version of fastjet-contrib"                 OFF)
+option(SKHEPFJ_PATCH_FJCORE                  "Patch fastjet-contrib with CMAKE_INSTALL_LIBDIR use"                  ON)
+option(SKHEPFJ_PATCH_FJCONTRIB               "Patch fastjet-contrib with cmake build"                               ON)
+option(SKHEPFJ_PASSTHRU_FASTJET_SWIG         "Create a _swig.py that just imports <fastjet-lib python module>"      OFF)
+option(SKHEPFJ_COPY_GMP_DLL                  "On Windows, force a copy of the amp runtime .dll to the wheel area"   OFF)
+
+set(SKHEPFJ_FASTJET_LIB_PYMODULE_NAME "fastjet_cxx" CACHE STRING "The name of the installed fastjet python package.")
 
 set(PKG_INSTALL "fastjet") ## python package name
 
@@ -44,6 +48,10 @@ else()
   add_subdirectory(${CMAKE_SOURCE_DIR}/extern/fastjet-contrib)
 endif()
 
+if (SKHEPFJ_PASSTHRU_FASTJET_SWIG)
+  file(WRITE ${CMAKE_INSTALL_PREFIX}/_swig.py "from ${SKHEPFJ_FASTJET_LIB_PYMODULE_NAME} import *\n")
+endif()
+
 pybind11_add_module(_ext MODULE src/_ext.cpp)
 target_link_libraries(_ext
                       PRIVATE
@@ -57,12 +65,12 @@ target_include_directories(_ext PRIVATE ${CMAKE_BINARY_DIR}/include)
 #set_target_properties(_ext PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
 #set_target_properties(_ext PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set_target_properties(_ext PROPERTIES INSTALL_RPATH "@loader_path/${CMAKE_INSTALL_LIBDIR}")
+  set_target_properties(_ext PROPERTIES INSTALL_RPATH "@loader_path/${CMAKE_INSTALL_LIBDIR};@loader_path/../../../../${CMAKE_INSTALL_LIBDIR}")
 elseif(NOT MSVC)
-  set_target_properties(_ext PROPERTIES INSTALL_RPATH "$ORIGIN/${CMAKE_INSTALL_LIBDIR}")
+  set_target_properties(_ext PROPERTIES INSTALL_RPATH "$ORIGIN/${CMAKE_INSTALL_LIBDIR}:$ORIGIN/../../../../${CMAKE_INSTALL_LIBDIR}")
 endif()
 
-if (MSVC AND FASTJET_ENABLE_CGAL)
+if (SKHEPFJ_COPY_GMP_DLL AND MSVC AND FASTJET_ENABLE_CGAL)
   message("-- Copying ${GMP_DLL_TO_COPY} to project area!")
   install(FILES ${GMP_DLL_TO_COPY} DESTINATION ${CMAKE_INSTALL_PREFIX})
 endif()


### PR DESCRIPTION
- applies and improves a patch from conda-forge that allows a passthru-patch to the system-installed fastjet swig module
  - NB: it must have a different name from `fastjet`, anyone doing this manually will likely know how to do that (and fastjet has corresponding options)
  - allow user to set the system fastjet swig module name in the passthru import
- add an option for copying the gmp dll on windows