### PR TITLE
build: add 3.14t testing and wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.9", "3.14", "3.14t"]
         runs-on: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, windows-11-arm]
         arch: [auto64]
         exclude:
@@ -117,7 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, windows-11-arm]
-        python: [314]
+        python: [314, '314t']
         arch: [auto64, universal2]
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [39, 310, 311, 312, 313, 314]
+        python: [39, 310, 311, 312, 313, 314, '314t']
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, windows-11-arm]
         arch: [auto64, universal2]
         exclude:


### PR DESCRIPTION
This does not make this package threadsafe, and does not mark the module as such.
This is only to provide wheels.