### PR TITLE
fix: Fixing broken ECF function in _generalevent.py

### DIFF
--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -763,7 +763,7 @@ class _classgeneralevent:
         njets=1,
         beta=1,
         npoint=0,
-        angles: int= -1,
+        angles: int = -1,
         alpha=0,
         func="generalized",
         normalized=True,

--- a/src/fastjet/_generalevent.py
+++ b/src/fastjet/_generalevent.py
@@ -761,9 +761,9 @@ class _classgeneralevent:
     def exclusive_jets_energy_correlator(
         self,
         njets=1,
-        n_point=0,
-        angles: int = -1,
         beta=1,
+        npoint=0,
+        angles: int= -1,
         alpha=0,
         func="generalized",
         normalized=True,
@@ -774,10 +774,18 @@ class _classgeneralevent:
         self._out = []
         self._input_flag = 0
         for i in range(len(self._clusterable_level)):
-            np_results = self._results[i].to_numpy_energy_correlators()
+            np_results = self._results[i].to_numpy_energy_correlators(
+                njets,
+                beta,
+                npoint,
+                angles,
+                alpha,
+                func,
+                normalized,
+            )
             self._out.append(
                 ak.Array(
-                    ak.contents.NumpyArray(np_results[0]),
+                    ak.contents.NumpyArray(np_results),
                     behavior=self.data.behavior,
                     attrs=self.data.attrs,
                 )

--- a/src/fastjet/_pyjet.py
+++ b/src/fastjet/_pyjet.py
@@ -549,7 +549,7 @@ class DaskAwkwardClusterSequence(ClusterSequence):
         angles=-1,
         alpha=0,
         func="generalized",
-        normalized=False,
+        normalized=True,
     ):
         return _dak_dispatch(
             self,


### PR DESCRIPTION
Hello! 

I was alerted to a few issues with the way the ECF function was constructed in `_generalevent.py`. To be specific:

1. None of the arguments were being passed to C++, so it would return the defaults in `_ext.cpp`
2. Input arguments in the wrong order
3. C++ returns an array (size and data), and `_generalevent.py` previously returned just the first element.

All of these are fixed in this pull request. As a small extra bit, The DaskAwkward cluster sequence previously had `normalized=False` in `_pyjet.py`, while other arguments for normalized were all set to `True`, so I updated that for consistency.